### PR TITLE
fix: dataset link merge bug #378

### DIFF
--- a/internal/graphql/resolver_property.go
+++ b/internal/graphql/resolver_property.go
@@ -470,7 +470,7 @@ func actualValue(datasetLoader dataloader.DatasetDataLoader, value interface{}, 
 		return &value, nil
 	}
 	// 先頭のリンクにしかDatasetが割り当てられていない→先頭から順々に辿っていく
-	if len(links) >= 1 && links[0].DatasetID != nil && links[len(links)-1].DatasetID == nil {
+	if len(links) > 1 && links[0].DatasetID != nil && links[len(links)-1].DatasetID == nil {
 		dsid := *links[0].DatasetID
 		for i, link := range links {
 			ds, err := datasetLoader.Load(id.DatasetID(dsid))

--- a/internal/graphql/resolver_property.go
+++ b/internal/graphql/resolver_property.go
@@ -142,7 +142,7 @@ func (r *propertyFieldResolver) ActualValue(ctx context.Context, obj *graphql1.P
 	defer exit()
 
 	datasetLoader := dataloader.DataLoadersFromContext(ctx).Dataset
-	return actualValue(datasetLoader, obj.Value, obj.Links)
+	return actualValue(datasetLoader, obj.Value, obj.Links, false)
 }
 
 func (r *propertySchemaFieldResolver) TranslatedTitle(ctx context.Context, obj *graphql1.PropertySchemaField, lang *string) (string, error) {
@@ -422,7 +422,7 @@ func (r *mergedPropertyFieldResolver) ActualValue(ctx context.Context, obj *grap
 	defer exit()
 
 	datasetLoader := dataloader.DataLoadersFromContext(ctx).Dataset
-	return actualValue(datasetLoader, obj.Value, obj.Links)
+	return actualValue(datasetLoader, obj.Value, obj.Links, obj.Overridden)
 }
 
 type propertyGroupListResolver struct{ *Resolver }
@@ -465,12 +465,12 @@ func (*propertyGroupResolver) SchemaGroup(ctx context.Context, obj *graphql1.Pro
 	return s.Group(obj.SchemaGroupID), nil
 }
 
-func actualValue(datasetLoader dataloader.DatasetDataLoader, value interface{}, links []*graphql1.PropertyFieldLink) (interface{}, error) {
-	if len(links) == 0 {
+func actualValue(datasetLoader dataloader.DatasetDataLoader, value interface{}, links []*graphql1.PropertyFieldLink, overridden bool) (interface{}, error) {
+	if len(links) == 0 || overridden {
 		return &value, nil
 	}
 	// 先頭のリンクにしかDatasetが割り当てられていない→先頭から順々に辿っていく
-	if len(links) > 1 && links[0].DatasetID != nil && links[len(links)-1].DatasetID == nil {
+	if len(links) >= 1 && links[0].DatasetID != nil && links[len(links)-1].DatasetID == nil {
 		dsid := *links[0].DatasetID
 		for i, link := range links {
 			ds, err := datasetLoader.Load(id.DatasetID(dsid))

--- a/internal/graphql/resolver_property_test.go
+++ b/internal/graphql/resolver_property_test.go
@@ -1,0 +1,50 @@
+package graphql
+
+import (
+	"testing"
+
+	graphql1 "github.com/reearth/reearth-backend/internal/adapter/graphql"
+	"github.com/reearth/reearth-backend/internal/graphql/dataloader"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_actualValue(t *testing.T) {
+	value := 300
+
+	type args struct {
+		datasetLoader dataloader.DatasetDataLoader
+		value         interface{}
+		links         []*graphql1.PropertyFieldLink
+		overridden    bool
+	}
+	var tests = []struct {
+		name    string
+		args    args
+		want    interface{}
+		wantErr bool
+	}{
+		{
+			"Overridden value",
+			args{
+				datasetLoader: nil,
+				value:         value,
+				links:         nil,
+				overridden:    true,
+			},
+			300,
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := actualValue(tt.args.datasetLoader, tt.args.value, tt.args.links, tt.args.overridden)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("actualValue() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			temp := got.(*interface{})
+			t2 := (*temp).(int)
+			assert.Equal(t, tt.want, t2)
+		})
+	}
+}


### PR DESCRIPTION
# Overview
When a dataset child layer is linked and overrides that link, the value isn't correctly merged.

## What I've done
Returned the overridden value if its overridden

## What I haven't done

## How I tested
By writing a unit test to test that case

## Which point I want you to review particularly
Not sure if the solution may effect the other scenarios

## Memo
