### PR TITLE
fix: KML coordinates splitting 

### DIFF
--- a/pkg/layer/decoding/kml.go
+++ b/pkg/layer/decoding/kml.go
@@ -51,7 +51,7 @@ func coordinatesToLatLngHeight(c string) (*property.LatLng, float64, error) {
 
 func coordinatesToLatLngHeightList(c string) ([]property.LatLngHeight, error) {
 	var LatLngHeighList []property.LatLngHeight
-	coords := strings.Split(c, "\n")
+	coords := strings.Fields(c)
 	for _, llh := range coords {
 		reg, err := regexp.Compile(`\s+`)
 		if err != nil {


### PR DESCRIPTION
# Overview
Fix the bug that KML coordinates were not decoded for "\t" separator
## What I've done
replaced strings.Split() with strings.Fields() to cover all white spaces

## What I haven't done

## How I tested
 separated coordinates for each white-space

## Which point I want you to review particularly

## Memo
