### PR TITLE
feat: Refine dataset import

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -31,6 +31,8 @@ models:
     model: github.com/reearth/reearth-backend/internal/adapter/graphql.PropertySchemaID
   PropertySchemaFieldID:
     model: github.com/reearth/reearth-backend/internal/adapter/graphql.PropertySchemaFieldID
+  DatasetSchemaFieldID:
+    model: github.com/reearth/reearth-backend/internal/adapter/graphql.DatasetSchemaFieldID
   TranslatedString:
     model: github.com/reearth/reearth-backend/internal/adapter/graphql.Map
   Lang:

--- a/internal/adapter/graphql/controller_layer.go
+++ b/internal/adapter/graphql/controller_layer.go
@@ -56,6 +56,7 @@ func (c *LayerController) AddGroup(ctx context.Context, ginput *AddLayerGroupInp
 		Index:                 ginput.Index,
 		Name:                  refToString(ginput.Name),
 		LinkedDatasetSchemaID: id.DatasetSchemaIDFromRefID(ginput.LinkedDatasetSchemaID),
+		MarkerTitleFieldId:    ginput.MarkerTitleFieldID,
 	}, operator)
 	if err != nil {
 		return nil, err

--- a/internal/adapter/graphql/controller_layer.go
+++ b/internal/adapter/graphql/controller_layer.go
@@ -56,7 +56,7 @@ func (c *LayerController) AddGroup(ctx context.Context, ginput *AddLayerGroupInp
 		Index:                 ginput.Index,
 		Name:                  refToString(ginput.Name),
 		LinkedDatasetSchemaID: id.DatasetSchemaIDFromRefID(ginput.LinkedDatasetSchemaID),
-		MarkerTitleFieldId:    ginput.MarkerTitleFieldID,
+		RepresentativeFieldId: ginput.RepresentativeFieldID,
 	}, operator)
 	if err != nil {
 		return nil, err

--- a/internal/adapter/graphql/models_gen.go
+++ b/internal/adapter/graphql/models_gen.go
@@ -82,7 +82,7 @@ type AddLayerGroupInput struct {
 	Index                 *int                     `json:"index"`
 	LinkedDatasetSchemaID *id.ID                   `json:"linkedDatasetSchemaID"`
 	Name                  *string                  `json:"name"`
-	MarkerTitleFieldID    *id.DatasetSchemaFieldID `json:"markerTitleFieldId"`
+	RepresentativeFieldID *id.DatasetSchemaFieldID `json:"representativeFieldId"`
 }
 
 type AddLayerGroupPayload struct {

--- a/internal/adapter/graphql/models_gen.go
+++ b/internal/adapter/graphql/models_gen.go
@@ -76,12 +76,13 @@ type AddInfoboxFieldPayload struct {
 }
 
 type AddLayerGroupInput struct {
-	ParentLayerID         id.ID                 `json:"parentLayerId"`
-	PluginID              *id.PluginID          `json:"pluginId"`
-	ExtensionID           *id.PluginExtensionID `json:"extensionId"`
-	Index                 *int                  `json:"index"`
-	LinkedDatasetSchemaID *id.ID                `json:"linkedDatasetSchemaID"`
-	Name                  *string               `json:"name"`
+	ParentLayerID         id.ID                    `json:"parentLayerId"`
+	PluginID              *id.PluginID             `json:"pluginId"`
+	ExtensionID           *id.PluginExtensionID    `json:"extensionId"`
+	Index                 *int                     `json:"index"`
+	LinkedDatasetSchemaID *id.ID                   `json:"linkedDatasetSchemaID"`
+	Name                  *string                  `json:"name"`
+	MarkerTitleFieldID    *id.DatasetSchemaFieldID `json:"markerTitleFieldId"`
 }
 
 type AddLayerGroupPayload struct {

--- a/internal/adapter/graphql/scalar.go
+++ b/internal/adapter/graphql/scalar.go
@@ -129,6 +129,19 @@ func UnmarshalPropertySchemaFieldID(v interface{}) (id.PropertySchemaFieldID, er
 	return id.PropertySchemaFieldID(""), errors.New("invalid ID")
 }
 
+func MarshalDatasetSchemaFieldID(t id.DatasetSchemaFieldID) graphql1.Marshaler {
+	return graphql1.WriterFunc(func(w io.Writer) {
+		_, _ = io.WriteString(w, strconv.Quote(t.String()))
+	})
+}
+
+func UnmarshalDatasetSchemaFieldID(v interface{}) (id.DatasetSchemaFieldID, error) {
+	if tmpStr, ok := v.(string); ok {
+		return id.DatasetSchemaFieldIDFrom(tmpStr)
+	}
+	return id.NewDatasetSchemaFieldID(), errors.New("invalid ID")
+}
+
 func MarshalMap(val map[string]string) graphql1.Marshaler {
 	return graphql1.WriterFunc(func(w io.Writer) {
 		_ = json.NewEncoder(w).Encode(val)

--- a/internal/graphql/generated.go
+++ b/internal/graphql/generated.go
@@ -5531,6 +5531,7 @@ scalar PluginExtensionID
 scalar PropertySchemaID
 scalar PropertySchemaFieldID
 scalar TranslatedString
+scalar DatasetSchemaFieldID
 
 type LatLng {
   lat: Float!
@@ -6501,6 +6502,7 @@ input AddLayerGroupInput {
   index: Int
   linkedDatasetSchemaID: ID
   name: String
+  markerTitleFieldId: DatasetSchemaFieldID
 }
 
 input RemoveLayerInput {
@@ -28983,6 +28985,14 @@ func (ec *executionContext) unmarshalInputAddLayerGroupInput(ctx context.Context
 			if err != nil {
 				return it, err
 			}
+		case "markerTitleFieldId":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("markerTitleFieldId"))
+			it.MarkerTitleFieldID, err = ec.unmarshalODatasetSchemaFieldID2ᚖgithubᚗcomᚋreearthᚋreearthᚑbackendᚋpkgᚋidᚐDatasetSchemaFieldID(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		}
 	}
 
@@ -39642,6 +39652,21 @@ func (ec *executionContext) marshalODatasetSchemaField2ᚖgithubᚗcomᚋreearth
 		return graphql.Null
 	}
 	return ec._DatasetSchemaField(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalODatasetSchemaFieldID2ᚖgithubᚗcomᚋreearthᚋreearthᚑbackendᚋpkgᚋidᚐDatasetSchemaFieldID(ctx context.Context, v interface{}) (*id.DatasetSchemaFieldID, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := graphql1.UnmarshalDatasetSchemaFieldID(v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalODatasetSchemaFieldID2ᚖgithubᚗcomᚋreearthᚋreearthᚑbackendᚋpkgᚋidᚐDatasetSchemaFieldID(ctx context.Context, sel ast.SelectionSet, v *id.DatasetSchemaFieldID) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return graphql1.MarshalDatasetSchemaFieldID(*v)
 }
 
 func (ec *executionContext) unmarshalODateTime2ᚖtimeᚐTime(ctx context.Context, v interface{}) (*time.Time, error) {

--- a/internal/graphql/generated.go
+++ b/internal/graphql/generated.go
@@ -6502,7 +6502,7 @@ input AddLayerGroupInput {
   index: Int
   linkedDatasetSchemaID: ID
   name: String
-  markerTitleFieldId: DatasetSchemaFieldID
+  representativeFieldId: DatasetSchemaFieldID
 }
 
 input RemoveLayerInput {
@@ -28985,11 +28985,11 @@ func (ec *executionContext) unmarshalInputAddLayerGroupInput(ctx context.Context
 			if err != nil {
 				return it, err
 			}
-		case "markerTitleFieldId":
+		case "representativeFieldId":
 			var err error
 
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("markerTitleFieldId"))
-			it.MarkerTitleFieldID, err = ec.unmarshalODatasetSchemaFieldID2ᚖgithubᚗcomᚋreearthᚋreearthᚑbackendᚋpkgᚋidᚐDatasetSchemaFieldID(ctx, v)
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("representativeFieldId"))
+			it.RepresentativeFieldID, err = ec.unmarshalODatasetSchemaFieldID2ᚖgithubᚗcomᚋreearthᚋreearthᚑbackendᚋpkgᚋidᚐDatasetSchemaFieldID(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/internal/usecase/interactor/layer.go
+++ b/internal/usecase/interactor/layer.go
@@ -354,6 +354,7 @@ func (i *Layer) AddGroup(ctx context.Context, inp interfaces.AddLayerGroupInput,
 	}
 
 	// create item layers
+	layerTitleFieldId := inp.MarkerTitleFieldId
 	representativeFieldID := datasetSchema.RepresentativeFieldID()
 	layerItems := make([]*layer.Item, 0, len(ds))
 	layerItemProperties := make([]*property.Property, 0, len(ds))
@@ -364,6 +365,11 @@ func (i *Layer) AddGroup(ctx context.Context, inp interfaces.AddLayerGroupInput,
 		name := ""
 		if rf := ds.FieldRef(representativeFieldID); rf != nil && rf.Type() == dataset.ValueTypeString {
 			name = rf.Value().Value().(string)
+		}
+		if name == "" && layerTitleFieldId != nil {
+			if rf := ds.FieldRef(layerTitleFieldId); rf != nil && rf.Type() == dataset.ValueTypeString {
+				name = rf.Value().Value().(string)
+			}
 		}
 
 		layerItem, property, err := initializer.LayerItem{

--- a/internal/usecase/interactor/layer.go
+++ b/internal/usecase/interactor/layer.go
@@ -354,8 +354,13 @@ func (i *Layer) AddGroup(ctx context.Context, inp interfaces.AddLayerGroupInput,
 	}
 
 	// create item layers
-	layerTitleFieldId := inp.MarkerTitleFieldId
-	representativeFieldID := datasetSchema.RepresentativeFieldID()
+	var representativeFieldID *id.DatasetSchemaFieldID
+	if inp.RepresentativeFieldId != nil {
+		representativeFieldID = inp.RepresentativeFieldId
+	} else {
+		representativeFieldID = datasetSchema.RepresentativeFieldID()
+	}
+
 	layerItems := make([]*layer.Item, 0, len(ds))
 	layerItemProperties := make([]*property.Property, 0, len(ds))
 	index := -1
@@ -365,11 +370,6 @@ func (i *Layer) AddGroup(ctx context.Context, inp interfaces.AddLayerGroupInput,
 		name := ""
 		if rf := ds.FieldRef(representativeFieldID); rf != nil && rf.Type() == dataset.ValueTypeString {
 			name = rf.Value().Value().(string)
-		}
-		if name == "" && layerTitleFieldId != nil {
-			if rf := ds.FieldRef(layerTitleFieldId); rf != nil && rf.Type() == dataset.ValueTypeString {
-				name = rf.Value().Value().(string)
-			}
 		}
 
 		layerItem, property, err := initializer.LayerItem{

--- a/internal/usecase/interfaces/layer.go
+++ b/internal/usecase/interfaces/layer.go
@@ -28,6 +28,7 @@ type AddLayerGroupInput struct {
 	ExtensionID           *id.PluginExtensionID
 	Index                 *int
 	LinkedDatasetSchemaID *id.DatasetSchemaID
+	MarkerTitleFieldId    *id.DatasetSchemaFieldID
 	Name                  string
 }
 

--- a/internal/usecase/interfaces/layer.go
+++ b/internal/usecase/interfaces/layer.go
@@ -28,7 +28,7 @@ type AddLayerGroupInput struct {
 	ExtensionID           *id.PluginExtensionID
 	Index                 *int
 	LinkedDatasetSchemaID *id.DatasetSchemaID
-	MarkerTitleFieldId    *id.DatasetSchemaFieldID
+	RepresentativeFieldId *id.DatasetSchemaFieldID
 	Name                  string
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -25,6 +25,7 @@ scalar PluginExtensionID
 scalar PropertySchemaID
 scalar PropertySchemaFieldID
 scalar TranslatedString
+scalar DatasetSchemaFieldID
 
 type LatLng {
   lat: Float!
@@ -995,6 +996,7 @@ input AddLayerGroupInput {
   index: Int
   linkedDatasetSchemaID: ID
   name: String
+  markerTitleFieldId: DatasetSchemaFieldID
 }
 
 input RemoveLayerInput {

--- a/schema.graphql
+++ b/schema.graphql
@@ -996,7 +996,7 @@ input AddLayerGroupInput {
   index: Int
   linkedDatasetSchemaID: ID
   name: String
-  markerTitleFieldId: DatasetSchemaFieldID
+  representativeFieldId: DatasetSchemaFieldID
 }
 
 input RemoveLayerInput {


### PR DESCRIPTION
# Overview
Add ability to set the layer name from dataset column

## What I've done
- Extend AddLayerGroupInput to accept optional markerTitleFieldId
- Use selected Field value as layer name

## What I haven't done

## How I tested

## Which point I want you to review particularly
specially the graphQL schema so we can start the front-end development

## Memo
The layer primitive type was implemented I've just tested it