### PR TITLE
fix: local asset bug

### DIFF
--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -25,7 +25,7 @@ type Config struct {
 	Tracer       string
 	TracerSample float64
 	GCS          GCSConfig
-	AssetBaseURL string
+	AssetBaseURL string `default:"http://localhost:8080/assets"`
 	Origins      []string
 	Web          WebConfig
 	SignupSecret string


### PR DESCRIPTION
# Overview
Fixes a bug where Asset images were not seen in local environment. The URL saved with the asset was just the file name.

## What I've done
Added default url to AssetBaseURL in config. Now local assets saved will default to `http://localhost:8080/assets/XX`

## What I haven't done

## How I tested
Created a new asset and checked if it is retrievable with the asset's URL on the front-end

## Which point I want you to review particularly
Do I need a migration???
## Memo
