### PR TITLE
fix: skip nil geometries

### DIFF
--- a/pkg/layer/decoding/geojson.go
+++ b/pkg/layer/decoding/geojson.go
@@ -31,9 +31,12 @@ func NewGeoJSONDecoder(r io.Reader, s id.SceneID) *GeoJSONDecoder {
 	}
 }
 
-func disassembleMultipolygon(fc []*geojson.Feature) []*geojson.Feature {
+func validateFeatures(fc []*geojson.Feature) []*geojson.Feature {
 	var res []*geojson.Feature
 	for _, f := range fc {
+		if f.Geometry == nil {
+			continue
+		}
 		if f.Geometry.Type == geojson.GeometryMultiPolygon {
 			for _, p := range f.Geometry.MultiPolygon {
 				nf := geojson.NewPolygonFeature(p)
@@ -65,7 +68,7 @@ func (d *GeoJSONDecoder) Decode() (Result, error) {
 	if err != nil {
 		return Result{}, errors.New("unable to parse file content")
 	}
-	fl := disassembleMultipolygon(fc.Features)
+	fl := validateFeatures(fc.Features)
 	// if feature collection > append it to features list, else try to decode a single feature (layer)
 	if len(fc.Features) > 0 {
 		d.features = fl

--- a/pkg/layer/decoding/geojson_test.go
+++ b/pkg/layer/decoding/geojson_test.go
@@ -100,6 +100,17 @@ const geojsonmock = `{
         }
       }
     },
+{
+            "type": "Feature",
+            "geometry": null,
+            "properties": {
+                "N03_001": "愛知県",
+                "N03_002": null,
+                "N03_003": null,
+                "N03_004": "豊橋市",
+                "N03_007": "23201"
+            }
+        },
     {
       "type": "Feature",
       "geometry": {


### PR DESCRIPTION
# Overview
skip a geoJSON feature when it doesn't has a geometry to decode
## What I've done
skip nil geos 

## What I haven't done

## How I tested

## Which point do I want you to review particularly
validation function 
## Memo
