### PR TITLE
refactor: reorganize graphql schema

### DIFF
--- a/internal/adapter/gql/generated.go
+++ b/internal/adapter/gql/generated.go
@@ -154,11 +154,6 @@ type ComplexityRoot struct {
 		Roll     func(childComplexity int) int
 	}
 
-	CheckProjectAliasPayload struct {
-		Alias     func(childComplexity int) int
-		Available func(childComplexity int) int
-	}
-
 	CreateAssetPayload struct {
 		Asset func(childComplexity int) int
 	}
@@ -572,6 +567,11 @@ type ComplexityRoot struct {
 		Visualizer        func(childComplexity int) int
 	}
 
+	ProjectAliasAvailability struct {
+		Alias     func(childComplexity int) int
+		Available func(childComplexity int) int
+	}
+
 	ProjectConnection struct {
 		Edges      func(childComplexity int) int
 		Nodes      func(childComplexity int) int
@@ -672,7 +672,6 @@ type ComplexityRoot struct {
 
 	PropertySchemaField struct {
 		AllTranslatedDescription func(childComplexity int) int
-		AllTranslatedName        func(childComplexity int) int
 		AllTranslatedTitle       func(childComplexity int) int
 		Choices                  func(childComplexity int) int
 		DefaultValue             func(childComplexity int) int
@@ -681,25 +680,20 @@ type ComplexityRoot struct {
 		IsAvailableIf            func(childComplexity int) int
 		Max                      func(childComplexity int) int
 		Min                      func(childComplexity int) int
-		Name                     func(childComplexity int) int
 		Prefix                   func(childComplexity int) int
 		Suffix                   func(childComplexity int) int
 		Title                    func(childComplexity int) int
 		TranslatedDescription    func(childComplexity int, lang *string) int
-		TranslatedName           func(childComplexity int, lang *string) int
 		TranslatedTitle          func(childComplexity int, lang *string) int
 		Type                     func(childComplexity int) int
 		UI                       func(childComplexity int) int
 	}
 
 	PropertySchemaFieldChoice struct {
-		AllTranslatedLabel func(childComplexity int) int
 		AllTranslatedTitle func(childComplexity int) int
 		Icon               func(childComplexity int) int
 		Key                func(childComplexity int) int
-		Label              func(childComplexity int) int
 		Title              func(childComplexity int) int
-		TranslatedLabel    func(childComplexity int, lang *string) int
 		TranslatedTitle    func(childComplexity int, lang *string) int
 	}
 
@@ -708,7 +702,6 @@ type ComplexityRoot struct {
 		Fields                func(childComplexity int) int
 		IsAvailableIf         func(childComplexity int) int
 		IsList                func(childComplexity int) int
-		Name                  func(childComplexity int) int
 		RepresentativeField   func(childComplexity int) int
 		RepresentativeFieldID func(childComplexity int) int
 		Schema                func(childComplexity int) int
@@ -773,9 +766,8 @@ type ComplexityRoot struct {
 	}
 
 	RemoveWidgetPayload struct {
-		ExtensionID func(childComplexity int) int
-		PluginID    func(childComplexity int) int
-		Scene       func(childComplexity int) int
+		Scene    func(childComplexity int) int
+		WidgetID func(childComplexity int) int
 	}
 
 	Scene struct {
@@ -1108,12 +1100,10 @@ type PropertyLinkableFieldsResolver interface {
 }
 type PropertySchemaFieldResolver interface {
 	TranslatedTitle(ctx context.Context, obj *gqlmodel.PropertySchemaField, lang *string) (string, error)
-	TranslatedName(ctx context.Context, obj *gqlmodel.PropertySchemaField, lang *string) (string, error)
 	TranslatedDescription(ctx context.Context, obj *gqlmodel.PropertySchemaField, lang *string) (string, error)
 }
 type PropertySchemaFieldChoiceResolver interface {
 	TranslatedTitle(ctx context.Context, obj *gqlmodel.PropertySchemaFieldChoice, lang *string) (string, error)
-	TranslatedLabel(ctx context.Context, obj *gqlmodel.PropertySchemaFieldChoice, lang *string) (string, error)
 }
 type PropertySchemaGroupResolver interface {
 	Schema(ctx context.Context, obj *gqlmodel.PropertySchemaGroup) (*gqlmodel.PropertySchema, error)
@@ -1136,7 +1126,7 @@ type QueryResolver interface {
 	SceneLock(ctx context.Context, sceneID id.ID) (*gqlmodel.SceneLockMode, error)
 	DynamicDatasetSchemas(ctx context.Context, sceneID id.ID) ([]*gqlmodel.DatasetSchema, error)
 	SearchUser(ctx context.Context, nameOrEmail string) (*gqlmodel.SearchedUser, error)
-	CheckProjectAlias(ctx context.Context, alias string) (*gqlmodel.CheckProjectAliasPayload, error)
+	CheckProjectAlias(ctx context.Context, alias string) (*gqlmodel.ProjectAliasAvailability, error)
 	InstallablePlugins(ctx context.Context) ([]*gqlmodel.PluginMetadata, error)
 }
 type SceneResolver interface {
@@ -1434,20 +1424,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Camera.Roll(childComplexity), true
-
-	case "CheckProjectAliasPayload.alias":
-		if e.complexity.CheckProjectAliasPayload.Alias == nil {
-			break
-		}
-
-		return e.complexity.CheckProjectAliasPayload.Alias(childComplexity), true
-
-	case "CheckProjectAliasPayload.available":
-		if e.complexity.CheckProjectAliasPayload.Available == nil {
-			break
-		}
-
-		return e.complexity.CheckProjectAliasPayload.Available(childComplexity), true
 
 	case "CreateAssetPayload.asset":
 		if e.complexity.CreateAssetPayload.Asset == nil {
@@ -3837,6 +3813,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Project.Visualizer(childComplexity), true
 
+	case "ProjectAliasAvailability.alias":
+		if e.complexity.ProjectAliasAvailability.Alias == nil {
+			break
+		}
+
+		return e.complexity.ProjectAliasAvailability.Alias(childComplexity), true
+
+	case "ProjectAliasAvailability.available":
+		if e.complexity.ProjectAliasAvailability.Available == nil {
+			break
+		}
+
+		return e.complexity.ProjectAliasAvailability.Available(childComplexity), true
+
 	case "ProjectConnection.edges":
 		if e.complexity.ProjectConnection.Edges == nil {
 			break
@@ -4257,13 +4247,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.PropertySchemaField.AllTranslatedDescription(childComplexity), true
 
-	case "PropertySchemaField.allTranslatedName":
-		if e.complexity.PropertySchemaField.AllTranslatedName == nil {
-			break
-		}
-
-		return e.complexity.PropertySchemaField.AllTranslatedName(childComplexity), true
-
 	case "PropertySchemaField.allTranslatedTitle":
 		if e.complexity.PropertySchemaField.AllTranslatedTitle == nil {
 			break
@@ -4320,13 +4303,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.PropertySchemaField.Min(childComplexity), true
 
-	case "PropertySchemaField.name":
-		if e.complexity.PropertySchemaField.Name == nil {
-			break
-		}
-
-		return e.complexity.PropertySchemaField.Name(childComplexity), true
-
 	case "PropertySchemaField.prefix":
 		if e.complexity.PropertySchemaField.Prefix == nil {
 			break
@@ -4360,18 +4336,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.PropertySchemaField.TranslatedDescription(childComplexity, args["lang"].(*string)), true
 
-	case "PropertySchemaField.translatedName":
-		if e.complexity.PropertySchemaField.TranslatedName == nil {
-			break
-		}
-
-		args, err := ec.field_PropertySchemaField_translatedName_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.PropertySchemaField.TranslatedName(childComplexity, args["lang"].(*string)), true
-
 	case "PropertySchemaField.translatedTitle":
 		if e.complexity.PropertySchemaField.TranslatedTitle == nil {
 			break
@@ -4398,13 +4362,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.PropertySchemaField.UI(childComplexity), true
 
-	case "PropertySchemaFieldChoice.allTranslatedLabel":
-		if e.complexity.PropertySchemaFieldChoice.AllTranslatedLabel == nil {
-			break
-		}
-
-		return e.complexity.PropertySchemaFieldChoice.AllTranslatedLabel(childComplexity), true
-
 	case "PropertySchemaFieldChoice.allTranslatedTitle":
 		if e.complexity.PropertySchemaFieldChoice.AllTranslatedTitle == nil {
 			break
@@ -4426,31 +4383,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.PropertySchemaFieldChoice.Key(childComplexity), true
 
-	case "PropertySchemaFieldChoice.label":
-		if e.complexity.PropertySchemaFieldChoice.Label == nil {
-			break
-		}
-
-		return e.complexity.PropertySchemaFieldChoice.Label(childComplexity), true
-
 	case "PropertySchemaFieldChoice.title":
 		if e.complexity.PropertySchemaFieldChoice.Title == nil {
 			break
 		}
 
 		return e.complexity.PropertySchemaFieldChoice.Title(childComplexity), true
-
-	case "PropertySchemaFieldChoice.translatedLabel":
-		if e.complexity.PropertySchemaFieldChoice.TranslatedLabel == nil {
-			break
-		}
-
-		args, err := ec.field_PropertySchemaFieldChoice_translatedLabel_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.PropertySchemaFieldChoice.TranslatedLabel(childComplexity, args["lang"].(*string)), true
 
 	case "PropertySchemaFieldChoice.translatedTitle":
 		if e.complexity.PropertySchemaFieldChoice.TranslatedTitle == nil {
@@ -4491,13 +4429,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.PropertySchemaGroup.IsList(childComplexity), true
-
-	case "PropertySchemaGroup.name":
-		if e.complexity.PropertySchemaGroup.Name == nil {
-			break
-		}
-
-		return e.complexity.PropertySchemaGroup.Name(childComplexity), true
 
 	case "PropertySchemaGroup.representativeField":
 		if e.complexity.PropertySchemaGroup.RepresentativeField == nil {
@@ -4843,26 +4774,19 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.RemoveMemberFromTeamPayload.Team(childComplexity), true
 
-	case "RemoveWidgetPayload.extensionId":
-		if e.complexity.RemoveWidgetPayload.ExtensionID == nil {
-			break
-		}
-
-		return e.complexity.RemoveWidgetPayload.ExtensionID(childComplexity), true
-
-	case "RemoveWidgetPayload.pluginId":
-		if e.complexity.RemoveWidgetPayload.PluginID == nil {
-			break
-		}
-
-		return e.complexity.RemoveWidgetPayload.PluginID(childComplexity), true
-
 	case "RemoveWidgetPayload.scene":
 		if e.complexity.RemoveWidgetPayload.Scene == nil {
 			break
 		}
 
 		return e.complexity.RemoveWidgetPayload.Scene(childComplexity), true
+
+	case "RemoveWidgetPayload.widgetId":
+		if e.complexity.RemoveWidgetPayload.WidgetID == nil {
+			break
+		}
+
+		return e.complexity.RemoveWidgetPayload.WidgetID(childComplexity), true
 
 	case "Scene.createdAt":
 		if e.complexity.Scene.CreatedAt == nil {
@@ -5497,9 +5421,38 @@ directive @goField(
   name: String
 ) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 
-# Basic types
+# Meta Type
 
 scalar Cursor
+
+interface Node {
+  id: ID!
+}
+
+enum NodeType {
+  ASSET
+  USER
+  TEAM
+  PROJECT
+  PLUGIN
+  SCENE
+  PROPERTY_SCHEMA
+  PROPERTY
+  DATASET_SCHEMA
+  DATASET
+  LAYER_GROUP
+  LAYER_ITEM
+}
+
+type PageInfo {
+  startCursor: Cursor
+  endCursor: Cursor
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+}
+
+# Basic types
+
 scalar DateTime
 scalar URL
 scalar Lang
@@ -5508,8 +5461,8 @@ scalar PluginID
 scalar PluginExtensionID
 scalar PropertySchemaID
 scalar PropertySchemaFieldID
-scalar TranslatedString
 scalar DatasetSchemaFieldID
+scalar TranslatedString
 
 type LatLng {
   lat: Float!
@@ -5585,19 +5538,6 @@ enum Theme {
   DARK
 }
 
-# Meta Type
-
-interface Node {
-  id: ID!
-}
-
-type PageInfo {
-  startCursor: Cursor
-  endCursor: Cursor
-  hasNextPage: Boolean!
-  hasPreviousPage: Boolean!
-}
-
 # Asset
 
 type Asset implements Node {
@@ -5631,7 +5571,7 @@ type SearchedUser {
   userEmail: String!
 }
 
-type CheckProjectAliasPayload {
+type ProjectAliasAvailability {
   alias: String!
   available: Boolean!
 }
@@ -5839,8 +5779,6 @@ type PropertySchemaGroup {
   isAvailableIf: PropertyCondition
   title: String
   allTranslatedTitle: TranslatedString
-  # For compatibility: "name" field will be removed in the futrue
-  name: PropertySchemaFieldID
   representativeFieldId: PropertySchemaFieldID
   representativeField: PropertySchemaField
   schema: PropertySchema @goField(forceResolver: true)
@@ -5851,8 +5789,6 @@ type PropertySchemaField {
   fieldId: PropertySchemaFieldID!
   type: ValueType!
   title: String!
-  # For compatibility: "name" field will be removed in the futrue
-  name: String!
   description: String!
   prefix: String
   suffix: String
@@ -5863,12 +5799,8 @@ type PropertySchemaField {
   choices: [PropertySchemaFieldChoice!]
   isAvailableIf: PropertyCondition
   allTranslatedTitle: TranslatedString
-  # For compatibility: "allTranslatedName" field will be removed in the futrue
-  allTranslatedName: TranslatedString
   allTranslatedDescription: TranslatedString
   translatedTitle(lang: String): String! @goField(forceResolver: true)
-  # For compatibility: "translatedName" field will be removed in the futrue
-  translatedName(lang: String): String! @goField(forceResolver: true)
   translatedDescription(lang: String): String! @goField(forceResolver: true)
 }
 
@@ -5887,15 +5819,9 @@ enum PropertySchemaFieldUI {
 type PropertySchemaFieldChoice {
   key: String!
   title: String!
-  # For compatibility: "label" field will be removed in the futrue
-  label: String!
   icon: String
   allTranslatedTitle: TranslatedString
-  # For compatibility: "allTranslatedLabel" field will be removed in the futrue
-  allTranslatedLabel: TranslatedString
   translatedTitle(lang: String): String! @goField(forceResolver: true)
-  # For compatibility: "translatedLabel" field will be removed in the futrue
-  translatedLabel(lang: String): String! @goField(forceResolver: true)
 }
 
 type PropertyCondition {
@@ -6191,6 +6117,7 @@ type MergedInfoboxField {
 }
 
 # InputType
+
 input CreateAssetInput {
   teamId: ID!
   file: Upload!
@@ -6311,15 +6238,13 @@ input AddWidgetInput {
 
 input UpdateWidgetInput {
   sceneId: ID!
-  pluginId: PluginID!
-  extensionId: PluginExtensionID!
+  widgetId: ID!
   enabled: Boolean
 }
 
 input RemoveWidgetInput {
   sceneId: ID!
-  pluginId: PluginID!
-  extensionId: PluginExtensionID!
+  widgetId: ID!
 }
 
 input InstallPluginInput {
@@ -6531,6 +6456,7 @@ input AddDatasetSchemaInput {
 }
 
 # Payload
+
 type CreateAssetPayload {
   asset: Asset!
 }
@@ -6606,8 +6532,7 @@ type UpdateWidgetPayload {
 
 type RemoveWidgetPayload {
   scene: Scene!
-  pluginId: PluginID!
-  extensionId: PluginExtensionID!
+  widgetId: ID!
 }
 
 type InstallPluginPayload {
@@ -6726,21 +6651,6 @@ type AddDatasetSchemaPayload {
 
 # Connection
 
-enum NodeType {
-  ASSET
-  USER
-  TEAM
-  PROJECT
-  PLUGIN
-  SCENE
-  PROPERTY_SCHEMA
-  PROPERTY
-  DATASET_SCHEMA
-  DATASET
-  LAYER_GROUP
-  LAYER_ITEM
-}
-
 type AssetConnection {
   edges: [AssetEdge!]!
   nodes: [Asset]!
@@ -6833,7 +6743,7 @@ type Query {
   sceneLock(sceneId: ID!): SceneLockMode
   dynamicDatasetSchemas(sceneId: ID!): [DatasetSchema!]!
   searchUser(nameOrEmail: String!): SearchedUser
-  checkProjectAlias(alias: String!): CheckProjectAliasPayload!
+  checkProjectAlias(alias: String!): ProjectAliasAvailability!
   installablePlugins: [PluginMetadata!]!
 }
 
@@ -7843,21 +7753,6 @@ func (ec *executionContext) field_Plugin_translatedName_args(ctx context.Context
 	return args, nil
 }
 
-func (ec *executionContext) field_PropertySchemaFieldChoice_translatedLabel_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
-	var err error
-	args := map[string]interface{}{}
-	var arg0 *string
-	if tmp, ok := rawArgs["lang"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("lang"))
-		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["lang"] = arg0
-	return args, nil
-}
-
 func (ec *executionContext) field_PropertySchemaFieldChoice_translatedTitle_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
@@ -7874,21 +7769,6 @@ func (ec *executionContext) field_PropertySchemaFieldChoice_translatedTitle_args
 }
 
 func (ec *executionContext) field_PropertySchemaField_translatedDescription_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
-	var err error
-	args := map[string]interface{}{}
-	var arg0 *string
-	if tmp, ok := rawArgs["lang"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("lang"))
-		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["lang"] = arg0
-	return args, nil
-}
-
-func (ec *executionContext) field_PropertySchemaField_translatedName_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
 	var arg0 *string
@@ -9766,76 +9646,6 @@ func (ec *executionContext) _Camera_fov(ctx context.Context, field graphql.Colle
 	res := resTmp.(float64)
 	fc.Result = res
 	return ec.marshalNFloat2float64(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _CheckProjectAliasPayload_alias(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.CheckProjectAliasPayload) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "CheckProjectAliasPayload",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   false,
-		IsResolver: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Alias, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _CheckProjectAliasPayload_available(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.CheckProjectAliasPayload) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "CheckProjectAliasPayload",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   false,
-		IsResolver: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Available, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(bool)
-	fc.Result = res
-	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _CreateAssetPayload_asset(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.CreateAssetPayload) (ret graphql.Marshaler) {
@@ -20227,6 +20037,76 @@ func (ec *executionContext) _Project_scene(ctx context.Context, field graphql.Co
 	return ec.marshalOScene2ᚖgithubᚗcomᚋreearthᚋreearthᚑbackendᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐScene(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _ProjectAliasAvailability_alias(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.ProjectAliasAvailability) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "ProjectAliasAvailability",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Alias, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _ProjectAliasAvailability_available(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.ProjectAliasAvailability) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "ProjectAliasAvailability",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Available, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _ProjectConnection_edges(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.ProjectConnection) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -22316,41 +22196,6 @@ func (ec *executionContext) _PropertySchemaField_title(ctx context.Context, fiel
 	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _PropertySchemaField_name(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.PropertySchemaField) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "PropertySchemaField",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   false,
-		IsResolver: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Name, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
 func (ec *executionContext) _PropertySchemaField_description(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.PropertySchemaField) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -22674,38 +22519,6 @@ func (ec *executionContext) _PropertySchemaField_allTranslatedTitle(ctx context.
 	return ec.marshalOTranslatedString2map(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _PropertySchemaField_allTranslatedName(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.PropertySchemaField) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "PropertySchemaField",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   false,
-		IsResolver: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.AllTranslatedName, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(map[string]string)
-	fc.Result = res
-	return ec.marshalOTranslatedString2map(ctx, field.Selections, res)
-}
-
 func (ec *executionContext) _PropertySchemaField_allTranslatedDescription(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.PropertySchemaField) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -22764,48 +22577,6 @@ func (ec *executionContext) _PropertySchemaField_translatedTitle(ctx context.Con
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
 		return ec.resolvers.PropertySchemaField().TranslatedTitle(rctx, obj, args["lang"].(*string))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _PropertySchemaField_translatedName(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.PropertySchemaField) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "PropertySchemaField",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   true,
-		IsResolver: true,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	rawArgs := field.ArgumentMap(ec.Variables)
-	args, err := ec.field_PropertySchemaField_translatedName_args(ctx, rawArgs)
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	fc.Args = args
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.PropertySchemaField().TranslatedName(rctx, obj, args["lang"].(*string))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -22934,41 +22705,6 @@ func (ec *executionContext) _PropertySchemaFieldChoice_title(ctx context.Context
 	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _PropertySchemaFieldChoice_label(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.PropertySchemaFieldChoice) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "PropertySchemaFieldChoice",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   false,
-		IsResolver: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Label, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
 func (ec *executionContext) _PropertySchemaFieldChoice_icon(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.PropertySchemaFieldChoice) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -23033,38 +22769,6 @@ func (ec *executionContext) _PropertySchemaFieldChoice_allTranslatedTitle(ctx co
 	return ec.marshalOTranslatedString2map(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _PropertySchemaFieldChoice_allTranslatedLabel(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.PropertySchemaFieldChoice) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "PropertySchemaFieldChoice",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   false,
-		IsResolver: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.AllTranslatedLabel, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(map[string]string)
-	fc.Result = res
-	return ec.marshalOTranslatedString2map(ctx, field.Selections, res)
-}
-
 func (ec *executionContext) _PropertySchemaFieldChoice_translatedTitle(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.PropertySchemaFieldChoice) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -23091,48 +22795,6 @@ func (ec *executionContext) _PropertySchemaFieldChoice_translatedTitle(ctx conte
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
 		return ec.resolvers.PropertySchemaFieldChoice().TranslatedTitle(rctx, obj, args["lang"].(*string))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _PropertySchemaFieldChoice_translatedLabel(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.PropertySchemaFieldChoice) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "PropertySchemaFieldChoice",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   true,
-		IsResolver: true,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	rawArgs := field.ArgumentMap(ec.Variables)
-	args, err := ec.field_PropertySchemaFieldChoice_translatedLabel_args(ctx, rawArgs)
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	fc.Args = args
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.PropertySchemaFieldChoice().TranslatedLabel(rctx, obj, args["lang"].(*string))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -23383,38 +23045,6 @@ func (ec *executionContext) _PropertySchemaGroup_allTranslatedTitle(ctx context.
 	res := resTmp.(map[string]string)
 	fc.Result = res
 	return ec.marshalOTranslatedString2map(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _PropertySchemaGroup_name(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.PropertySchemaGroup) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "PropertySchemaGroup",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   false,
-		IsResolver: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Name, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*id.PropertySchemaFieldID)
-	fc.Result = res
-	return ec.marshalOPropertySchemaFieldID2ᚖgithubᚗcomᚋreearthᚋreearthᚑbackendᚋpkgᚋidᚐPropertySchemaFieldID(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _PropertySchemaGroup_representativeFieldId(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.PropertySchemaGroup) (ret graphql.Marshaler) {
@@ -24233,9 +23863,9 @@ func (ec *executionContext) _Query_checkProjectAlias(ctx context.Context, field 
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*gqlmodel.CheckProjectAliasPayload)
+	res := resTmp.(*gqlmodel.ProjectAliasAvailability)
 	fc.Result = res
-	return ec.marshalNCheckProjectAliasPayload2ᚖgithubᚗcomᚋreearthᚋreearthᚑbackendᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐCheckProjectAliasPayload(ctx, field.Selections, res)
+	return ec.marshalNProjectAliasAvailability2ᚖgithubᚗcomᚋreearthᚋreearthᚑbackendᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐProjectAliasAvailability(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query_installablePlugins(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -24799,7 +24429,7 @@ func (ec *executionContext) _RemoveWidgetPayload_scene(ctx context.Context, fiel
 	return ec.marshalNScene2ᚖgithubᚗcomᚋreearthᚋreearthᚑbackendᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐScene(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _RemoveWidgetPayload_pluginId(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.RemoveWidgetPayload) (ret graphql.Marshaler) {
+func (ec *executionContext) _RemoveWidgetPayload_widgetId(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.RemoveWidgetPayload) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
 			ec.Error(ctx, ec.Recover(ctx, r))
@@ -24817,7 +24447,7 @@ func (ec *executionContext) _RemoveWidgetPayload_pluginId(ctx context.Context, f
 	ctx = graphql.WithFieldContext(ctx, fc)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.PluginID, nil
+		return obj.WidgetID, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -24829,44 +24459,9 @@ func (ec *executionContext) _RemoveWidgetPayload_pluginId(ctx context.Context, f
 		}
 		return graphql.Null
 	}
-	res := resTmp.(id.PluginID)
+	res := resTmp.(id.ID)
 	fc.Result = res
-	return ec.marshalNPluginID2githubᚗcomᚋreearthᚋreearthᚑbackendᚋpkgᚋidᚐPluginID(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _RemoveWidgetPayload_extensionId(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.RemoveWidgetPayload) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "RemoveWidgetPayload",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   false,
-		IsResolver: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.ExtensionID, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(id.PluginExtensionID)
-	fc.Result = res
-	return ec.marshalNPluginExtensionID2githubᚗcomᚋreearthᚋreearthᚑbackendᚋpkgᚋidᚐPluginExtensionID(ctx, field.Selections, res)
+	return ec.marshalNID2githubᚗcomᚋreearthᚋreearthᚑbackendᚋpkgᚋidᚐID(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Scene_id(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.Scene) (ret graphql.Marshaler) {
@@ -29878,19 +29473,11 @@ func (ec *executionContext) unmarshalInputRemoveWidgetInput(ctx context.Context,
 			if err != nil {
 				return it, err
 			}
-		case "pluginId":
+		case "widgetId":
 			var err error
 
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("pluginId"))
-			it.PluginID, err = ec.unmarshalNPluginID2githubᚗcomᚋreearthᚋreearthᚑbackendᚋpkgᚋidᚐPluginID(ctx, v)
-			if err != nil {
-				return it, err
-			}
-		case "extensionId":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("extensionId"))
-			it.ExtensionID, err = ec.unmarshalNPluginExtensionID2githubᚗcomᚋreearthᚋreearthᚑbackendᚋpkgᚋidᚐPluginExtensionID(ctx, v)
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("widgetId"))
+			it.WidgetID, err = ec.unmarshalNID2githubᚗcomᚋreearthᚋreearthᚑbackendᚋpkgᚋidᚐID(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -30534,19 +30121,11 @@ func (ec *executionContext) unmarshalInputUpdateWidgetInput(ctx context.Context,
 			if err != nil {
 				return it, err
 			}
-		case "pluginId":
+		case "widgetId":
 			var err error
 
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("pluginId"))
-			it.PluginID, err = ec.unmarshalNPluginID2githubᚗcomᚋreearthᚋreearthᚑbackendᚋpkgᚋidᚐPluginID(ctx, v)
-			if err != nil {
-				return it, err
-			}
-		case "extensionId":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("extensionId"))
-			it.ExtensionID, err = ec.unmarshalNPluginExtensionID2githubᚗcomᚋreearthᚋreearthᚑbackendᚋpkgᚋidᚐPluginExtensionID(ctx, v)
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("widgetId"))
+			it.WidgetID, err = ec.unmarshalNID2githubᚗcomᚋreearthᚋreearthᚑbackendᚋpkgᚋidᚐID(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -31252,38 +30831,6 @@ func (ec *executionContext) _Camera(ctx context.Context, sel ast.SelectionSet, o
 			}
 		case "fov":
 			out.Values[i] = ec._Camera_fov(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch()
-	if invalids > 0 {
-		return graphql.Null
-	}
-	return out
-}
-
-var checkProjectAliasPayloadImplementors = []string{"CheckProjectAliasPayload"}
-
-func (ec *executionContext) _CheckProjectAliasPayload(ctx context.Context, sel ast.SelectionSet, obj *gqlmodel.CheckProjectAliasPayload) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, checkProjectAliasPayloadImplementors)
-
-	out := graphql.NewFieldSet(fields)
-	var invalids uint32
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("CheckProjectAliasPayload")
-		case "alias":
-			out.Values[i] = ec._CheckProjectAliasPayload_alias(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		case "available":
-			out.Values[i] = ec._CheckProjectAliasPayload_available(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
@@ -33783,6 +33330,38 @@ func (ec *executionContext) _Project(ctx context.Context, sel ast.SelectionSet, 
 	return out
 }
 
+var projectAliasAvailabilityImplementors = []string{"ProjectAliasAvailability"}
+
+func (ec *executionContext) _ProjectAliasAvailability(ctx context.Context, sel ast.SelectionSet, obj *gqlmodel.ProjectAliasAvailability) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, projectAliasAvailabilityImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ProjectAliasAvailability")
+		case "alias":
+			out.Values[i] = ec._ProjectAliasAvailability_alias(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "available":
+			out.Values[i] = ec._ProjectAliasAvailability_available(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var projectConnectionImplementors = []string{"ProjectConnection"}
 
 func (ec *executionContext) _ProjectConnection(ctx context.Context, sel ast.SelectionSet, obj *gqlmodel.ProjectConnection) graphql.Marshaler {
@@ -34471,11 +34050,6 @@ func (ec *executionContext) _PropertySchemaField(ctx context.Context, sel ast.Se
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
-		case "name":
-			out.Values[i] = ec._PropertySchemaField_name(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
 		case "description":
 			out.Values[i] = ec._PropertySchemaField_description(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -34499,8 +34073,6 @@ func (ec *executionContext) _PropertySchemaField(ctx context.Context, sel ast.Se
 			out.Values[i] = ec._PropertySchemaField_isAvailableIf(ctx, field, obj)
 		case "allTranslatedTitle":
 			out.Values[i] = ec._PropertySchemaField_allTranslatedTitle(ctx, field, obj)
-		case "allTranslatedName":
-			out.Values[i] = ec._PropertySchemaField_allTranslatedName(ctx, field, obj)
 		case "allTranslatedDescription":
 			out.Values[i] = ec._PropertySchemaField_allTranslatedDescription(ctx, field, obj)
 		case "translatedTitle":
@@ -34512,20 +34084,6 @@ func (ec *executionContext) _PropertySchemaField(ctx context.Context, sel ast.Se
 					}
 				}()
 				res = ec._PropertySchemaField_translatedTitle(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&invalids, 1)
-				}
-				return res
-			})
-		case "translatedName":
-			field := field
-			out.Concurrently(i, func() (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._PropertySchemaField_translatedName(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&invalids, 1)
 				}
@@ -34577,17 +34135,10 @@ func (ec *executionContext) _PropertySchemaFieldChoice(ctx context.Context, sel 
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
-		case "label":
-			out.Values[i] = ec._PropertySchemaFieldChoice_label(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
 		case "icon":
 			out.Values[i] = ec._PropertySchemaFieldChoice_icon(ctx, field, obj)
 		case "allTranslatedTitle":
 			out.Values[i] = ec._PropertySchemaFieldChoice_allTranslatedTitle(ctx, field, obj)
-		case "allTranslatedLabel":
-			out.Values[i] = ec._PropertySchemaFieldChoice_allTranslatedLabel(ctx, field, obj)
 		case "translatedTitle":
 			field := field
 			out.Concurrently(i, func() (res graphql.Marshaler) {
@@ -34597,20 +34148,6 @@ func (ec *executionContext) _PropertySchemaFieldChoice(ctx context.Context, sel 
 					}
 				}()
 				res = ec._PropertySchemaFieldChoice_translatedTitle(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&invalids, 1)
-				}
-				return res
-			})
-		case "translatedLabel":
-			field := field
-			out.Concurrently(i, func() (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._PropertySchemaFieldChoice_translatedLabel(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&invalids, 1)
 				}
@@ -34664,8 +34201,6 @@ func (ec *executionContext) _PropertySchemaGroup(ctx context.Context, sel ast.Se
 			out.Values[i] = ec._PropertySchemaGroup_title(ctx, field, obj)
 		case "allTranslatedTitle":
 			out.Values[i] = ec._PropertySchemaGroup_allTranslatedTitle(ctx, field, obj)
-		case "name":
-			out.Values[i] = ec._PropertySchemaGroup_name(ctx, field, obj)
 		case "representativeFieldId":
 			out.Values[i] = ec._PropertySchemaGroup_representativeFieldId(ctx, field, obj)
 		case "representativeField":
@@ -35194,13 +34729,8 @@ func (ec *executionContext) _RemoveWidgetPayload(ctx context.Context, sel ast.Se
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
-		case "pluginId":
-			out.Values[i] = ec._RemoveWidgetPayload_pluginId(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		case "extensionId":
-			out.Values[i] = ec._RemoveWidgetPayload_extensionId(ctx, field, obj)
+		case "widgetId":
+			out.Values[i] = ec._RemoveWidgetPayload_widgetId(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
@@ -36515,20 +36045,6 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 	return res
 }
 
-func (ec *executionContext) marshalNCheckProjectAliasPayload2githubᚗcomᚋreearthᚋreearthᚑbackendᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐCheckProjectAliasPayload(ctx context.Context, sel ast.SelectionSet, v gqlmodel.CheckProjectAliasPayload) graphql.Marshaler {
-	return ec._CheckProjectAliasPayload(ctx, sel, &v)
-}
-
-func (ec *executionContext) marshalNCheckProjectAliasPayload2ᚖgithubᚗcomᚋreearthᚋreearthᚑbackendᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐCheckProjectAliasPayload(ctx context.Context, sel ast.SelectionSet, v *gqlmodel.CheckProjectAliasPayload) graphql.Marshaler {
-	if v == nil {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	return ec._CheckProjectAliasPayload(ctx, sel, v)
-}
-
 func (ec *executionContext) unmarshalNCreateAssetInput2githubᚗcomᚋreearthᚋreearthᚑbackendᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐCreateAssetInput(ctx context.Context, v interface{}) (gqlmodel.CreateAssetInput, error) {
 	res, err := ec.unmarshalInputCreateAssetInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -37809,6 +37325,20 @@ func (ec *executionContext) marshalNProject2ᚖgithubᚗcomᚋreearthᚋreearth�
 		return graphql.Null
 	}
 	return ec._Project(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNProjectAliasAvailability2githubᚗcomᚋreearthᚋreearthᚑbackendᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐProjectAliasAvailability(ctx context.Context, sel ast.SelectionSet, v gqlmodel.ProjectAliasAvailability) graphql.Marshaler {
+	return ec._ProjectAliasAvailability(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNProjectAliasAvailability2ᚖgithubᚗcomᚋreearthᚋreearthᚑbackendᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐProjectAliasAvailability(ctx context.Context, sel ast.SelectionSet, v *gqlmodel.ProjectAliasAvailability) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._ProjectAliasAvailability(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNProjectConnection2githubᚗcomᚋreearthᚋreearthᚑbackendᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐProjectConnection(ctx context.Context, sel ast.SelectionSet, v gqlmodel.ProjectConnection) graphql.Marshaler {

--- a/internal/adapter/gql/gqlmodel/convert_property.go
+++ b/internal/adapter/gql/gqlmodel/convert_property.go
@@ -394,9 +394,7 @@ func ToPropertySchemaField(f *property.SchemaField) *PropertySchemaField {
 			choices = append(choices, &PropertySchemaFieldChoice{
 				Key:                k.Key,
 				Title:              k.Title.String(),
-				Label:              k.Title.String(), // deprecated
 				AllTranslatedTitle: k.Title,
-				AllTranslatedLabel: k.Title, // deprecated
 				Icon:               stringToRef(k.Icon),
 			})
 		}
@@ -406,7 +404,6 @@ func ToPropertySchemaField(f *property.SchemaField) *PropertySchemaField {
 		FieldID:                  f.ID(),
 		Type:                     ToPropertyValueType(f.Type()),
 		Title:                    f.Title().String(),
-		Name:                     f.Title().String(), // deprecated
 		Description:              f.Description().String(),
 		Prefix:                   stringToRef(f.Prefix()),
 		Suffix:                   stringToRef(f.Suffix()),
@@ -417,7 +414,6 @@ func ToPropertySchemaField(f *property.SchemaField) *PropertySchemaField {
 		Choices:                  choices,
 		IsAvailableIf:            ToPropertyConditon(f.IsAvailableIf()),
 		AllTranslatedTitle:       f.Title(),
-		AllTranslatedName:        f.Title(), // deprecated
 		AllTranslatedDescription: f.Description(),
 	}
 }
@@ -542,7 +538,6 @@ func ToPropertySchemaGroup(g *property.SchemaGroup) *PropertySchemaGroup {
 		IsList:                g.IsList(),
 		Title:                 g.Title().StringRef(),
 		Fields:                fields,
-		Name:                  representativeFieldID, // deprecated
 		RepresentativeFieldID: representativeFieldID,
 		RepresentativeField:   representativeField,
 		AllTranslatedTitle:    g.Title(),

--- a/internal/adapter/gql/gqlmodel/models_gen.go
+++ b/internal/adapter/gql/gqlmodel/models_gen.go
@@ -171,11 +171,6 @@ type Camera struct {
 	Fov      float64 `json:"fov"`
 }
 
-type CheckProjectAliasPayload struct {
-	Alias     string `json:"alias"`
-	Available bool   `json:"available"`
-}
-
 type CreateAssetInput struct {
 	TeamID id.ID          `json:"teamId"`
 	File   graphql.Upload `json:"file"`
@@ -641,6 +636,11 @@ type Project struct {
 
 func (Project) IsNode() {}
 
+type ProjectAliasAvailability struct {
+	Alias     string `json:"alias"`
+	Available bool   `json:"available"`
+}
+
 type ProjectConnection struct {
 	Edges      []*ProjectEdge `json:"edges"`
 	Nodes      []*Project     `json:"nodes"`
@@ -749,7 +749,6 @@ type PropertySchemaField struct {
 	FieldID                  id.PropertySchemaFieldID     `json:"fieldId"`
 	Type                     ValueType                    `json:"type"`
 	Title                    string                       `json:"title"`
-	Name                     string                       `json:"name"`
 	Description              string                       `json:"description"`
 	Prefix                   *string                      `json:"prefix"`
 	Suffix                   *string                      `json:"suffix"`
@@ -760,22 +759,17 @@ type PropertySchemaField struct {
 	Choices                  []*PropertySchemaFieldChoice `json:"choices"`
 	IsAvailableIf            *PropertyCondition           `json:"isAvailableIf"`
 	AllTranslatedTitle       map[string]string            `json:"allTranslatedTitle"`
-	AllTranslatedName        map[string]string            `json:"allTranslatedName"`
 	AllTranslatedDescription map[string]string            `json:"allTranslatedDescription"`
 	TranslatedTitle          string                       `json:"translatedTitle"`
-	TranslatedName           string                       `json:"translatedName"`
 	TranslatedDescription    string                       `json:"translatedDescription"`
 }
 
 type PropertySchemaFieldChoice struct {
 	Key                string            `json:"key"`
 	Title              string            `json:"title"`
-	Label              string            `json:"label"`
 	Icon               *string           `json:"icon"`
 	AllTranslatedTitle map[string]string `json:"allTranslatedTitle"`
-	AllTranslatedLabel map[string]string `json:"allTranslatedLabel"`
 	TranslatedTitle    string            `json:"translatedTitle"`
-	TranslatedLabel    string            `json:"translatedLabel"`
 }
 
 type PropertySchemaGroup struct {
@@ -786,7 +780,6 @@ type PropertySchemaGroup struct {
 	IsAvailableIf         *PropertyCondition        `json:"isAvailableIf"`
 	Title                 *string                   `json:"title"`
 	AllTranslatedTitle    map[string]string         `json:"allTranslatedTitle"`
-	Name                  *id.PropertySchemaFieldID `json:"name"`
 	RepresentativeFieldID *id.PropertySchemaFieldID `json:"representativeFieldId"`
 	RepresentativeField   *PropertySchemaField      `json:"representativeField"`
 	Schema                *PropertySchema           `json:"schema"`
@@ -877,15 +870,13 @@ type RemovePropertyItemInput struct {
 }
 
 type RemoveWidgetInput struct {
-	SceneID     id.ID                `json:"sceneId"`
-	PluginID    id.PluginID          `json:"pluginId"`
-	ExtensionID id.PluginExtensionID `json:"extensionId"`
+	SceneID  id.ID `json:"sceneId"`
+	WidgetID id.ID `json:"widgetId"`
 }
 
 type RemoveWidgetPayload struct {
-	Scene       *Scene               `json:"scene"`
-	PluginID    id.PluginID          `json:"pluginId"`
-	ExtensionID id.PluginExtensionID `json:"extensionId"`
+	Scene    *Scene `json:"scene"`
+	WidgetID id.ID  `json:"widgetId"`
 }
 
 type Scene struct {
@@ -1096,10 +1087,9 @@ type UpdateTeamPayload struct {
 }
 
 type UpdateWidgetInput struct {
-	SceneID     id.ID                `json:"sceneId"`
-	PluginID    id.PluginID          `json:"pluginId"`
-	ExtensionID id.PluginExtensionID `json:"extensionId"`
-	Enabled     *bool                `json:"enabled"`
+	SceneID  id.ID `json:"sceneId"`
+	WidgetID id.ID `json:"widgetId"`
+	Enabled  *bool `json:"enabled"`
 }
 
 type UpdateWidgetPayload struct {

--- a/internal/adapter/gql/loader_project.go
+++ b/internal/adapter/gql/loader_project.go
@@ -57,13 +57,13 @@ func (c *ProjectLoader) FindByTeam(ctx context.Context, teamID id.TeamID, first 
 	}, nil
 }
 
-func (c *ProjectLoader) CheckAlias(ctx context.Context, alias string) (*gqlmodel.CheckProjectAliasPayload, error) {
+func (c *ProjectLoader) CheckAlias(ctx context.Context, alias string) (*gqlmodel.ProjectAliasAvailability, error) {
 	ok, err := c.usecase.CheckAlias(ctx, alias)
 	if err != nil {
 		return nil, err
 	}
 
-	return &gqlmodel.CheckProjectAliasPayload{Alias: alias, Available: ok}, nil
+	return &gqlmodel.ProjectAliasAvailability{Alias: alias, Available: ok}, nil
 }
 
 // data loaders

--- a/internal/adapter/gql/resolver_mutation_scene.go
+++ b/internal/adapter/gql/resolver_mutation_scene.go
@@ -55,10 +55,9 @@ func (r *mutationResolver) UpdateWidget(ctx context.Context, input gqlmodel.Upda
 	defer exit()
 
 	scene, widget, err := r.usecases.Scene.UpdateWidget(ctx, interfaces.UpdateWidgetParam{
-		SceneID:     id.SceneID(input.SceneID),
-		PluginID:    input.PluginID,
-		ExtensionID: id.PluginExtensionID(input.ExtensionID),
-		Enabled:     input.Enabled,
+		SceneID:  id.SceneID(input.SceneID),
+		WidgetID: id.WidgetID(input.WidgetID),
+		Enabled:  input.Enabled,
 	}, getOperator(ctx))
 	if err != nil {
 		return nil, err
@@ -76,8 +75,7 @@ func (r *mutationResolver) RemoveWidget(ctx context.Context, input gqlmodel.Remo
 
 	scene, err := r.usecases.Scene.RemoveWidget(ctx,
 		id.SceneID(input.SceneID),
-		id.PluginID(input.PluginID),
-		id.PluginExtensionID(input.ExtensionID),
+		id.WidgetID(input.WidgetID),
 		getOperator(ctx),
 	)
 	if err != nil {
@@ -85,9 +83,8 @@ func (r *mutationResolver) RemoveWidget(ctx context.Context, input gqlmodel.Remo
 	}
 
 	return &gqlmodel.RemoveWidgetPayload{
-		Scene:       gqlmodel.ToScene(scene),
-		PluginID:    input.PluginID,
-		ExtensionID: input.ExtensionID,
+		Scene:    gqlmodel.ToScene(scene),
+		WidgetID: input.WidgetID,
 	}, nil
 }
 

--- a/internal/adapter/gql/resolver_property_schema.go
+++ b/internal/adapter/gql/resolver_property_schema.go
@@ -31,18 +31,7 @@ func (r *propertySchemaFieldResolver) TranslatedTitle(ctx context.Context, obj *
 	if s, ok := obj.AllTranslatedTitle[getLang(ctx, lang)]; ok {
 		return s, nil
 	}
-	return obj.Name, nil
-}
-
-// deprecated
-func (r *propertySchemaFieldResolver) TranslatedName(ctx context.Context, obj *gqlmodel.PropertySchemaField, lang *string) (string, error) {
-	exit := trace(ctx)
-	defer exit()
-
-	if s, ok := obj.AllTranslatedName[getLang(ctx, lang)]; ok {
-		return s, nil
-	}
-	return obj.Name, nil
+	return obj.Title, nil
 }
 
 func (r *propertySchemaFieldResolver) TranslatedDescription(ctx context.Context, obj *gqlmodel.PropertySchemaField, lang *string) (string, error) {
@@ -112,13 +101,5 @@ func (r *propertySchemaFieldChoiceResolver) TranslatedTitle(ctx context.Context,
 	if s, ok := obj.AllTranslatedTitle[getLang(ctx, lang)]; ok {
 		return s, nil
 	}
-	return obj.Label, nil
-}
-
-// deprecated
-func (r *propertySchemaFieldChoiceResolver) TranslatedLabel(ctx context.Context, obj *gqlmodel.PropertySchemaFieldChoice, lang *string) (string, error) {
-	if s, ok := obj.AllTranslatedLabel[getLang(ctx, lang)]; ok {
-		return s, nil
-	}
-	return obj.Label, nil
+	return obj.Title, nil
 }

--- a/internal/adapter/gql/resolver_query.go
+++ b/internal/adapter/gql/resolver_query.go
@@ -326,7 +326,7 @@ func (r *queryResolver) SearchUser(ctx context.Context, nameOrEmail string) (*gq
 	return r.loaders.User.SearchUser(ctx, nameOrEmail)
 }
 
-func (r *queryResolver) CheckProjectAlias(ctx context.Context, alias string) (*gqlmodel.CheckProjectAliasPayload, error) {
+func (r *queryResolver) CheckProjectAlias(ctx context.Context, alias string) (*gqlmodel.ProjectAliasAvailability, error) {
 	exit := trace(ctx)
 	defer exit()
 

--- a/internal/usecase/interactor/scene.go
+++ b/internal/usecase/interactor/scene.go
@@ -68,7 +68,6 @@ func (i *Scene) FindByProject(ctx context.Context, id id.ProjectID, operator *us
 }
 
 func (i *Scene) Create(ctx context.Context, pid id.ProjectID, operator *usecase.Operator) (_ *scene.Scene, err error) {
-
 	tx, err := i.transaction.Begin()
 	if err != nil {
 		return
@@ -218,7 +217,6 @@ func (i *Scene) AddWidget(ctx context.Context, sid id.SceneID, pid id.PluginID, 
 }
 
 func (i *Scene) UpdateWidget(ctx context.Context, param interfaces.UpdateWidgetParam, operator *usecase.Operator) (_ *scene.Scene, _ *scene.Widget, err error) {
-
 	tx, err := i.transaction.Begin()
 	if err != nil {
 		return
@@ -247,7 +245,7 @@ func (i *Scene) UpdateWidget(ctx context.Context, param interfaces.UpdateWidgetP
 	}
 
 	ws := scene.WidgetSystem()
-	widget := ws.Widget(param.PluginID, param.ExtensionID)
+	widget := ws.Widget(param.WidgetID)
 	if widget == nil {
 		return nil, nil, rerror.ErrNotFound
 	}
@@ -265,7 +263,7 @@ func (i *Scene) UpdateWidget(ctx context.Context, param interfaces.UpdateWidgetP
 	return scene, widget, nil
 }
 
-func (i *Scene) RemoveWidget(ctx context.Context, id id.SceneID, pid id.PluginID, eid id.PluginExtensionID, operator *usecase.Operator) (_ *scene.Scene, err error) {
+func (i *Scene) RemoveWidget(ctx context.Context, id id.SceneID, wid id.WidgetID, operator *usecase.Operator) (_ *scene.Scene, err error) {
 
 	tx, err := i.transaction.Begin()
 	if err != nil {
@@ -296,12 +294,12 @@ func (i *Scene) RemoveWidget(ctx context.Context, id id.SceneID, pid id.PluginID
 
 	ws := scene.WidgetSystem()
 
-	widget := ws.Widget(pid, eid)
+	widget := ws.Widget(wid)
 	if widget == nil {
 		return nil, rerror.ErrNotFound
 	}
 
-	ws.Remove(pid, eid)
+	ws.Remove(wid)
 
 	err2 = i.propertyRepo.Remove(ctx, widget.Property())
 	if err2 != nil {

--- a/internal/usecase/interfaces/scene.go
+++ b/internal/usecase/interfaces/scene.go
@@ -10,10 +10,9 @@ import (
 )
 
 type UpdateWidgetParam struct {
-	SceneID     id.SceneID
-	PluginID    id.PluginID
-	ExtensionID id.PluginExtensionID
-	Enabled     *bool
+	SceneID  id.SceneID
+	WidgetID id.WidgetID
+	Enabled  *bool
 }
 
 var (
@@ -29,7 +28,7 @@ type Scene interface {
 	Create(context.Context, id.ProjectID, *usecase.Operator) (*scene.Scene, error)
 	AddWidget(context.Context, id.SceneID, id.PluginID, id.PluginExtensionID, *usecase.Operator) (*scene.Scene, *scene.Widget, error)
 	UpdateWidget(context.Context, UpdateWidgetParam, *usecase.Operator) (*scene.Scene, *scene.Widget, error)
-	RemoveWidget(context.Context, id.SceneID, id.PluginID, id.PluginExtensionID, *usecase.Operator) (*scene.Scene, error)
+	RemoveWidget(context.Context, id.SceneID, id.WidgetID, *usecase.Operator) (*scene.Scene, error)
 	InstallPlugin(context.Context, id.SceneID, id.PluginID, *usecase.Operator) (*scene.Scene, id.PluginID, *id.PropertyID, error)
 	UninstallPlugin(context.Context, id.SceneID, id.PluginID, *usecase.Operator) (*scene.Scene, error)
 	UpgradePlugin(context.Context, id.SceneID, id.PluginID, id.PluginID, *usecase.Operator) (*scene.Scene, error)

--- a/pkg/scene/widget_system.go
+++ b/pkg/scene/widget_system.go
@@ -45,24 +45,24 @@ func (w *WidgetSystem) Widgets() []*Widget {
 	return append([]*Widget{}, w.widgets...)
 }
 
-func (w *WidgetSystem) Widget(p id.PluginID, e id.PluginExtensionID) *Widget {
+func (w *WidgetSystem) Widget(wid id.WidgetID) *Widget {
 	if w == nil {
 		return nil
 	}
 	for _, ww := range w.widgets {
-		if ww.plugin.Equal(p) && ww.extension == e {
+		if ww.ID() == wid {
 			return ww
 		}
 	}
 	return nil
 }
 
-func (w *WidgetSystem) Has(p id.PluginID, e id.PluginExtensionID) bool {
+func (w *WidgetSystem) Has(wid id.WidgetID) bool {
 	if w == nil {
 		return false
 	}
 	for _, w2 := range w.widgets {
-		if w2.plugin.Equal(p) && w2.extension == e {
+		if w2.ID() == wid {
 			return true
 		}
 	}
@@ -70,21 +70,21 @@ func (w *WidgetSystem) Has(p id.PluginID, e id.PluginExtensionID) bool {
 }
 
 func (w *WidgetSystem) Add(sw *Widget) {
-	if w == nil || sw == nil || w.Has(sw.plugin, sw.extension) {
+	if w == nil || sw == nil || w.Has(sw.ID()) {
 		return
 	}
 	sw2 := *sw
 	w.widgets = append(w.widgets, &sw2)
 }
 
-func (w *WidgetSystem) Remove(p id.PluginID, e id.PluginExtensionID) {
+func (w *WidgetSystem) Remove(wid id.WidgetID) {
 	if w == nil {
 		return
 	}
 	for i := 0; i < len(w.widgets); i++ {
-		if w.widgets[i].plugin.Equal(p) && w.widgets[i].extension == e {
+		if w.widgets[i].ID() == wid {
 			w.widgets = append(w.widgets[:i], w.widgets[i+1:]...)
-			i--
+			return
 		}
 	}
 }
@@ -103,7 +103,21 @@ func (w *WidgetSystem) RemoveAllByPlugin(p id.PluginID) (res []id.PropertyID) {
 	return res
 }
 
-func (w *WidgetSystem) Replace(oldp, newp id.PluginID) {
+func (w *WidgetSystem) RemoveAllByExtension(p id.PluginID, e id.PluginExtensionID) (res []id.PropertyID) {
+	if w == nil {
+		return nil
+	}
+	for i := 0; i < len(w.widgets); i++ {
+		if w.widgets[i].Plugin().Equal(p) && w.widgets[i].Extension() == e {
+			res = append(res, w.widgets[i].Property())
+			w.widgets = append(w.widgets[:i], w.widgets[i+1:]...)
+			i--
+		}
+	}
+	return res
+}
+
+func (w *WidgetSystem) ReplacePlugin(oldp, newp id.PluginID) {
 	if w == nil || w.widgets == nil {
 		return
 	}

--- a/pkg/scene/widget_system_test.go
+++ b/pkg/scene/widget_system_test.go
@@ -147,19 +147,18 @@ func TestWidgetSystem_Remove(t *testing.T) {
 
 	testCases := []struct {
 		Name         string
-		PID          id.PluginID
-		EID          id.PluginExtensionID
+		ID           id.WidgetID
 		WS, Expected *WidgetSystem
 	}{
 		{
 			Name:     "remove a widget",
-			PID:      pid,
-			EID:      "e1",
+			ID:       w1.ID(),
 			WS:       NewWidgetSystem([]*Widget{w1, w2, w3, w4}),
-			Expected: NewWidgetSystem([]*Widget{w3, w4}),
+			Expected: NewWidgetSystem([]*Widget{w2, w3, w4}),
 		},
 		{
 			Name:     "remove from nil widgetSystem",
+			ID:       w1.ID(),
 			WS:       nil,
 			Expected: nil,
 		},
@@ -168,7 +167,7 @@ func TestWidgetSystem_Remove(t *testing.T) {
 		tc := tc
 		t.Run(tc.Name, func(tt *testing.T) {
 			tt.Parallel()
-			tc.WS.Remove(tc.PID, tc.EID)
+			tc.WS.Remove(tc.ID)
 			assert.Equal(tt, tc.Expected, tc.WS)
 		})
 	}
@@ -211,7 +210,49 @@ func TestWidgetSystem_RemoveAllByPlugin(t *testing.T) {
 	}
 }
 
-func TestWidgetSystem_Replace(t *testing.T) {
+func TestWidgetSystem_RemoveAllByExtension(t *testing.T) {
+	pid := id.MustPluginID("xxx~1.1.1")
+	pid2 := id.MustPluginID("xxx~1.1.2")
+	w1 := MustNewWidget(id.NewWidgetID(), pid, "e1", id.NewPropertyID(), true)
+	w2 := MustNewWidget(id.NewWidgetID(), pid, "e2", id.NewPropertyID(), true)
+	w3 := MustNewWidget(id.NewWidgetID(), pid, "e1", id.NewPropertyID(), true)
+	w4 := MustNewWidget(id.NewWidgetID(), pid2, "e1", id.NewPropertyID(), true)
+
+	testCases := []struct {
+		Name           string
+		PID            id.PluginID
+		EID            id.PluginExtensionID
+		WS, Expected   *WidgetSystem
+		ExpectedResult []id.PropertyID
+	}{
+		{
+			Name:           "remove widgets",
+			PID:            pid,
+			EID:            id.PluginExtensionID("e1"),
+			WS:             NewWidgetSystem([]*Widget{w1, w2, w3, w4}),
+			Expected:       NewWidgetSystem([]*Widget{w2, w4}),
+			ExpectedResult: []id.PropertyID{w1.Property(), w3.Property()},
+		},
+		{
+			Name:           "remove widgets from nil widget system",
+			PID:            pid,
+			EID:            id.PluginExtensionID("e1"),
+			WS:             nil,
+			Expected:       nil,
+			ExpectedResult: nil,
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.Name, func(tt *testing.T) {
+			tt.Parallel()
+			assert.Equal(tt, tc.ExpectedResult, tc.WS.RemoveAllByExtension(tc.PID, tc.EID))
+			assert.Equal(tt, tc.Expected, tc.WS)
+		})
+	}
+}
+
+func TestWidgetSystem_ReplacePlugin(t *testing.T) {
 	pid := id.MustPluginID("xxx~1.1.1")
 	pid2 := id.MustPluginID("zzz~1.1.1")
 	pr := id.NewPropertyID()
@@ -244,7 +285,7 @@ func TestWidgetSystem_Replace(t *testing.T) {
 		tc := tc
 		t.Run(tc.Name, func(tt *testing.T) {
 			tt.Parallel()
-			tc.WS.Replace(tc.PID, tc.NewID)
+			tc.WS.ReplacePlugin(tc.PID, tc.NewID)
 			assert.Equal(tt, tc.Expected, tc.WS)
 		})
 	}
@@ -329,27 +370,25 @@ func TestWidgetSystem_Widget(t *testing.T) {
 	wid := id.NewWidgetID()
 	testCases := []struct {
 		Name     string
-		PID      id.PluginID
-		EID      id.PluginExtensionID
+		ID       id.WidgetID
 		WS       *WidgetSystem
 		Expected *Widget
 	}{
 		{
 			Name:     "get a widget",
-			PID:      pid,
-			EID:      "eee",
+			ID:       wid,
 			WS:       NewWidgetSystem([]*Widget{MustNewWidget(wid, pid, "eee", pr, true)}),
 			Expected: MustNewWidget(wid, pid, "eee", pr, true),
 		},
 		{
 			Name:     "dont has the widget",
-			PID:      pid,
-			EID:      "eee",
+			ID:       wid,
 			WS:       NewWidgetSystem([]*Widget{}),
 			Expected: nil,
 		},
 		{
 			Name:     "get widget from nil widgetSystem",
+			ID:       wid,
 			WS:       nil,
 			Expected: nil,
 		},
@@ -358,7 +397,7 @@ func TestWidgetSystem_Widget(t *testing.T) {
 		tc := tc
 		t.Run(tc.Name, func(tt *testing.T) {
 			tt.Parallel()
-			res := tc.WS.Widget(tc.PID, tc.EID)
+			res := tc.WS.Widget(tc.ID)
 			assert.Equal(tt, tc.Expected, res)
 		})
 	}
@@ -370,27 +409,25 @@ func TestWidgetSystem_Has(t *testing.T) {
 	wid := id.NewWidgetID()
 	testCases := []struct {
 		Name     string
-		PID      id.PluginID
-		EID      id.PluginExtensionID
+		ID       id.WidgetID
 		WS       *WidgetSystem
 		Expected bool
 	}{
 		{
 			Name:     "has a widget",
-			PID:      pid,
-			EID:      "eee",
+			ID:       wid,
 			WS:       NewWidgetSystem([]*Widget{MustNewWidget(wid, pid, "eee", pr, true)}),
 			Expected: true,
 		},
 		{
 			Name:     "dont has a widget",
-			PID:      pid,
-			EID:      "eee",
+			ID:       wid,
 			WS:       NewWidgetSystem([]*Widget{}),
 			Expected: false,
 		},
 		{
 			Name:     "has from nil widgetSystem",
+			ID:       wid,
 			WS:       nil,
 			Expected: false,
 		},
@@ -399,7 +436,7 @@ func TestWidgetSystem_Has(t *testing.T) {
 		tc := tc
 		t.Run(tc.Name, func(tt *testing.T) {
 			tt.Parallel()
-			res := tc.WS.Has(tc.PID, tc.EID)
+			res := tc.WS.Has(tc.ID)
 			assert.Equal(tt, tc.Expected, res)
 		})
 	}

--- a/schema.graphql
+++ b/schema.graphql
@@ -13,9 +13,38 @@ directive @goField(
   name: String
 ) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
 
-# Basic types
+# Meta Type
 
 scalar Cursor
+
+interface Node {
+  id: ID!
+}
+
+enum NodeType {
+  ASSET
+  USER
+  TEAM
+  PROJECT
+  PLUGIN
+  SCENE
+  PROPERTY_SCHEMA
+  PROPERTY
+  DATASET_SCHEMA
+  DATASET
+  LAYER_GROUP
+  LAYER_ITEM
+}
+
+type PageInfo {
+  startCursor: Cursor
+  endCursor: Cursor
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+}
+
+# Basic types
+
 scalar DateTime
 scalar URL
 scalar Lang
@@ -24,8 +53,8 @@ scalar PluginID
 scalar PluginExtensionID
 scalar PropertySchemaID
 scalar PropertySchemaFieldID
-scalar TranslatedString
 scalar DatasetSchemaFieldID
+scalar TranslatedString
 
 type LatLng {
   lat: Float!
@@ -101,19 +130,6 @@ enum Theme {
   DARK
 }
 
-# Meta Type
-
-interface Node {
-  id: ID!
-}
-
-type PageInfo {
-  startCursor: Cursor
-  endCursor: Cursor
-  hasNextPage: Boolean!
-  hasPreviousPage: Boolean!
-}
-
 # Asset
 
 type Asset implements Node {
@@ -147,7 +163,7 @@ type SearchedUser {
   userEmail: String!
 }
 
-type CheckProjectAliasPayload {
+type ProjectAliasAvailability {
   alias: String!
   available: Boolean!
 }
@@ -355,8 +371,6 @@ type PropertySchemaGroup {
   isAvailableIf: PropertyCondition
   title: String
   allTranslatedTitle: TranslatedString
-  # For compatibility: "name" field will be removed in the futrue
-  name: PropertySchemaFieldID
   representativeFieldId: PropertySchemaFieldID
   representativeField: PropertySchemaField
   schema: PropertySchema @goField(forceResolver: true)
@@ -367,8 +381,6 @@ type PropertySchemaField {
   fieldId: PropertySchemaFieldID!
   type: ValueType!
   title: String!
-  # For compatibility: "name" field will be removed in the futrue
-  name: String!
   description: String!
   prefix: String
   suffix: String
@@ -379,12 +391,8 @@ type PropertySchemaField {
   choices: [PropertySchemaFieldChoice!]
   isAvailableIf: PropertyCondition
   allTranslatedTitle: TranslatedString
-  # For compatibility: "allTranslatedName" field will be removed in the futrue
-  allTranslatedName: TranslatedString
   allTranslatedDescription: TranslatedString
   translatedTitle(lang: String): String! @goField(forceResolver: true)
-  # For compatibility: "translatedName" field will be removed in the futrue
-  translatedName(lang: String): String! @goField(forceResolver: true)
   translatedDescription(lang: String): String! @goField(forceResolver: true)
 }
 
@@ -403,15 +411,9 @@ enum PropertySchemaFieldUI {
 type PropertySchemaFieldChoice {
   key: String!
   title: String!
-  # For compatibility: "label" field will be removed in the futrue
-  label: String!
   icon: String
   allTranslatedTitle: TranslatedString
-  # For compatibility: "allTranslatedLabel" field will be removed in the futrue
-  allTranslatedLabel: TranslatedString
   translatedTitle(lang: String): String! @goField(forceResolver: true)
-  # For compatibility: "translatedLabel" field will be removed in the futrue
-  translatedLabel(lang: String): String! @goField(forceResolver: true)
 }
 
 type PropertyCondition {
@@ -707,6 +709,7 @@ type MergedInfoboxField {
 }
 
 # InputType
+
 input CreateAssetInput {
   teamId: ID!
   file: Upload!
@@ -827,15 +830,13 @@ input AddWidgetInput {
 
 input UpdateWidgetInput {
   sceneId: ID!
-  pluginId: PluginID!
-  extensionId: PluginExtensionID!
+  widgetId: ID!
   enabled: Boolean
 }
 
 input RemoveWidgetInput {
   sceneId: ID!
-  pluginId: PluginID!
-  extensionId: PluginExtensionID!
+  widgetId: ID!
 }
 
 input InstallPluginInput {
@@ -1047,6 +1048,7 @@ input AddDatasetSchemaInput {
 }
 
 # Payload
+
 type CreateAssetPayload {
   asset: Asset!
 }
@@ -1122,8 +1124,7 @@ type UpdateWidgetPayload {
 
 type RemoveWidgetPayload {
   scene: Scene!
-  pluginId: PluginID!
-  extensionId: PluginExtensionID!
+  widgetId: ID!
 }
 
 type InstallPluginPayload {
@@ -1242,21 +1243,6 @@ type AddDatasetSchemaPayload {
 
 # Connection
 
-enum NodeType {
-  ASSET
-  USER
-  TEAM
-  PROJECT
-  PLUGIN
-  SCENE
-  PROPERTY_SCHEMA
-  PROPERTY
-  DATASET_SCHEMA
-  DATASET
-  LAYER_GROUP
-  LAYER_ITEM
-}
-
 type AssetConnection {
   edges: [AssetEdge!]!
   nodes: [Asset]!
@@ -1349,7 +1335,7 @@ type Query {
   sceneLock(sceneId: ID!): SceneLockMode
   dynamicDatasetSchemas(sceneId: ID!): [DatasetSchema!]!
   searchUser(nameOrEmail: String!): SearchedUser
-  checkProjectAlias(alias: String!): CheckProjectAliasPayload!
+  checkProjectAlias(alias: String!): ProjectAliasAvailability!
   installablePlugins: [PluginMetadata!]!
 }
 


### PR DESCRIPTION
# Overview

- Delete deprecated fields in GraphQL schema
- Change the name of some types
- `updateWidget` and `removeWidget` mutation accepts widgetId instead of pluginId and extensionId so that they support multiple widgets completely

Manually tested by reearth-web and I confirmed it works