### PR TITLE
ci: renovate bot not running on schedule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,7 +15,7 @@
       "enabledManagers": [
         "gomod"
       ],
-      "packagePatterns": [
+      "matchPackagePatterns": [
         "*"
       ],
       "groupName": "dependencies",
@@ -30,7 +30,7 @@
         "dockerfile",
         "docker-compose"
       ],
-      "packagePatterns": [
+      "matchPackagePatterns": [
         "*"
       ],
       "groupName": "docker dependencies",
@@ -44,7 +44,7 @@
       "enabledManagers": [
         "github-actions"
       ],
-      "packagePatterns": [
+      "matchPackagePatterns": [
         "*"
       ],
       "groupName": "github actions dependencies",


### PR DESCRIPTION
# Overview
Renovate bot didn't run at the scheduled time. There was a typo for each package rule (`packagePatterns` instead of `matchPackagePatterns`). This was the only issue I could see so should work now.