### PR TITLE
chore: typo `secrit` on env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,7 @@ REEARTH_AUTHSRV_DEV=true
 REEARTH_AUTHSRV_DISABLED=false
 REEARTH_AUTHSRV_UIDOMAIN=https://reearth.example.com
 REEARTH_AUTHSRV_DOMAIN=https://api.reearth.example.com
-# Any random long string (keep it secrit)
+# Any random long string (keep it secret)
 REEARTH_AUTHSRV_KEY=abcdefghijklmnopqrstuvwxyz
 
 # Available mailers: [log, smtp, sendgrid]


### PR DESCRIPTION
# Overview

## What I've done

I changed the `secrit` to `secret` on `.env.samples` comment for `REEARTH_AUTHSRV_KEY` environment variable.

## What I haven't done

## How I tested

Didn't as this change is on a comment.

## Which point I want you to review particularly

Nothing.

## Memo
