### PR TITLE
feat: add an opacity slider to map tiles

### DIFF
--- a/internal/adapter/gql/generated.go
+++ b/internal/adapter/gql/generated.go
@@ -6402,8 +6402,8 @@ type Me {
   email: String!
   lang: Lang!
   theme: Theme!
-  auths: [String!]!
   myTeamId: ID!
+  auths: [String!]!
   teams: [Team!]! @goField(forceResolver: true)
   myTeam: Team! @goField(forceResolver: true)
 }
@@ -6708,6 +6708,7 @@ enum PropertySchemaFieldUI {
   SELECTION
   COLOR
   RANGE
+  SLIDER
   IMAGE
   VIDEO
   FILE
@@ -15988,41 +15989,6 @@ func (ec *executionContext) _Me_theme(ctx context.Context, field graphql.Collect
 	return ec.marshalNTheme2githubᚗcomᚋreearthᚋreearthᚑbackendᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐTheme(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _Me_auths(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.Me) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "Me",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   false,
-		IsResolver: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Auths, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.([]string)
-	fc.Result = res
-	return ec.marshalNString2ᚕstringᚄ(ctx, field.Selections, res)
-}
-
 func (ec *executionContext) _Me_myTeamId(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.Me) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -16056,6 +16022,41 @@ func (ec *executionContext) _Me_myTeamId(ctx context.Context, field graphql.Coll
 	res := resTmp.(gqlmodel.ID)
 	fc.Result = res
 	return ec.marshalNID2githubᚗcomᚋreearthᚋreearthᚑbackendᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Me_auths(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.Me) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Me",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Auths, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	fc.Result = res
+	return ec.marshalNString2ᚕstringᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Me_teams(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.Me) (ret graphql.Marshaler) {
@@ -38446,9 +38447,9 @@ func (ec *executionContext) _Me(ctx context.Context, sel ast.SelectionSet, obj *
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
-		case "auths":
+		case "myTeamId":
 			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._Me_auths(ctx, field, obj)
+				return ec._Me_myTeamId(ctx, field, obj)
 			}
 
 			out.Values[i] = innerFunc(ctx)
@@ -38456,9 +38457,9 @@ func (ec *executionContext) _Me(ctx context.Context, sel ast.SelectionSet, obj *
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
-		case "myTeamId":
+		case "auths":
 			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._Me_myTeamId(ctx, field, obj)
+				return ec._Me_auths(ctx, field, obj)
 			}
 
 			out.Values[i] = innerFunc(ctx)

--- a/internal/adapter/gql/gqlmodel/convert_property.go
+++ b/internal/adapter/gql/gqlmodel/convert_property.go
@@ -276,6 +276,8 @@ func ToPropertySchemaFieldUI(ui *property.SchemaFieldUI) *PropertySchemaFieldUI 
 		ui2 = PropertySchemaFieldUIColor
 	case property.SchemaFieldUIRange:
 		ui2 = PropertySchemaFieldUIRange
+	case property.SchemaFieldUISlider:
+		ui2 = PropertySchemaFieldUISlider
 	case property.SchemaFieldUIImage:
 		ui2 = PropertySchemaFieldUIImage
 	case property.SchemaFieldUIVideo:

--- a/internal/adapter/gql/gqlmodel/models_gen.go
+++ b/internal/adapter/gql/gqlmodel/models_gen.go
@@ -555,8 +555,8 @@ type Me struct {
 	Email    string       `json:"email"`
 	Lang     language.Tag `json:"lang"`
 	Theme    Theme        `json:"theme"`
-	Auths    []string     `json:"auths"`
 	MyTeamID ID           `json:"myTeamId"`
+	Auths    []string     `json:"auths"`
 	Teams    []*Team      `json:"teams"`
 	MyTeam   *Team        `json:"myTeam"`
 }
@@ -1628,6 +1628,7 @@ const (
 	PropertySchemaFieldUISelection  PropertySchemaFieldUI = "SELECTION"
 	PropertySchemaFieldUIColor      PropertySchemaFieldUI = "COLOR"
 	PropertySchemaFieldUIRange      PropertySchemaFieldUI = "RANGE"
+	PropertySchemaFieldUISlider     PropertySchemaFieldUI = "SLIDER"
 	PropertySchemaFieldUIImage      PropertySchemaFieldUI = "IMAGE"
 	PropertySchemaFieldUIVideo      PropertySchemaFieldUI = "VIDEO"
 	PropertySchemaFieldUIFile       PropertySchemaFieldUI = "FILE"
@@ -1640,6 +1641,7 @@ var AllPropertySchemaFieldUI = []PropertySchemaFieldUI{
 	PropertySchemaFieldUISelection,
 	PropertySchemaFieldUIColor,
 	PropertySchemaFieldUIRange,
+	PropertySchemaFieldUISlider,
 	PropertySchemaFieldUIImage,
 	PropertySchemaFieldUIVideo,
 	PropertySchemaFieldUIFile,
@@ -1648,7 +1650,7 @@ var AllPropertySchemaFieldUI = []PropertySchemaFieldUI{
 
 func (e PropertySchemaFieldUI) IsValid() bool {
 	switch e {
-	case PropertySchemaFieldUILayer, PropertySchemaFieldUIMultiline, PropertySchemaFieldUISelection, PropertySchemaFieldUIColor, PropertySchemaFieldUIRange, PropertySchemaFieldUIImage, PropertySchemaFieldUIVideo, PropertySchemaFieldUIFile, PropertySchemaFieldUICameraPose:
+	case PropertySchemaFieldUILayer, PropertySchemaFieldUIMultiline, PropertySchemaFieldUISelection, PropertySchemaFieldUIColor, PropertySchemaFieldUIRange, PropertySchemaFieldUISlider, PropertySchemaFieldUIImage, PropertySchemaFieldUIVideo, PropertySchemaFieldUIFile, PropertySchemaFieldUICameraPose:
 		return true
 	}
 	return false

--- a/pkg/builtin/manifest.yml
+++ b/pkg/builtin/manifest.yml
@@ -24,7 +24,7 @@ extensions:
               description: Show elevation when close to the surface.
             - id: terrainType
               type: string
-              title: Terrain Type
+              title: Terrain type
               description: Specify terrain type.
               defaultValue: cesium
               choices:
@@ -89,7 +89,7 @@ extensions:
               description: Enable camera limiter.
             - id: cameraLimitterShowHelper
               type: bool
-              title: Show Helper
+              title: Show helper
               defaultValue: false
               description: Display the limiter boundaries.
             - id: cameraLimitterTargetArea
@@ -118,7 +118,7 @@ extensions:
           fields:
             - id: tile_type
               type: string
-              title: Tile Type
+              title: Tile type
               defaultValue: default
               choices:
                 - key: default
@@ -256,20 +256,20 @@ extensions:
               max: 1
             - id: brightness_shift
               type: number
-              title: Fog Brightness
+              title: Fog brightness
               defaultValue: 0.03
               description: "Set brightness of the fog. Min: -1 Max: 1"
               min: -1
               max: 1
             - id: hue_shift
               type: number
-              title: Fog Hue
+              title: Fog hue
               description: "Set hue of the fog. Min: -1 Max: 1"
               min: -1
               max: 1
             - id: surturation_shift
               type: number
-              title: Fog Saturation
+              title: Fog saturation
               description: "Set saturation of the fog. Min: -1 Max: 1"
               min: -1
               max: 1
@@ -308,7 +308,7 @@ extensions:
               title: Title
             - id: showTitle
               type: bool
-              title: Show Title
+              title: Show title
               defaultValue: true
             - id: position
               type: string
@@ -334,7 +334,7 @@ extensions:
                   label: Large
             - id: heightType
               type: string
-              title: Height Type
+              title: Height type
               defaultValue: auto
               choices:
                 - key: auto
@@ -382,7 +382,7 @@ extensions:
               description: "The space between the right side of the infobox and the title and blocks. Min: 0  Max: 40"
             - id: bgcolor
               type: string
-              title: Background Color
+              title: Background color
               ui: color
             - id: outlineWidth
               type: number
@@ -391,11 +391,11 @@ extensions:
               max: 20
             - id: outlineColor
               type: string
-              title: Outline Color
+              title: Outline color
               ui: color
             - id: useMask
               type: bool
-              title: Use Mask
+              title: Use mask
             - id: typography
               type: typography
               title: Font
@@ -1036,7 +1036,7 @@ extensions:
     schema:
       groups:
         - id: default
-          title: 3D Model
+          title: 3D model
           fields:
             - id: model
               type: url

--- a/pkg/builtin/manifest.yml
+++ b/pkg/builtin/manifest.yml
@@ -158,6 +158,13 @@ extensions:
               title: Maximum zoom level
               min: 0
               max: 30
+            - id: tile_opacity
+              type: number
+              title: Opacity
+              defaultValue: 1
+              ui: slider
+              min: 0
+              max: 1
         - id: theme
           title: Publish Theme
           description: Set your theme.

--- a/pkg/builtin/manifest.yml
+++ b/pkg/builtin/manifest.yml
@@ -161,6 +161,7 @@ extensions:
             - id: tile_opacity
               type: number
               title: Opacity
+              description: "Change the opacity of the selected tile map. Min: 0 Max: 1"
               defaultValue: 1
               ui: slider
               min: 0

--- a/pkg/builtin/manifest_ja.yml
+++ b/pkg/builtin/manifest_ja.yml
@@ -81,6 +81,7 @@ extensions:
             title: 最大レベル
           tile_opacity:
             title: 不透明性
+            description: NEEDS DESCRIPTION
       atmosphere:
         title: 大気
         description: 地球を覆う大気圏の設定ができます。

--- a/pkg/builtin/manifest_ja.yml
+++ b/pkg/builtin/manifest_ja.yml
@@ -79,6 +79,8 @@ extensions:
             title: 最小レベル
           tile_maxLevel:
             title: 最大レベル
+          tile_opacity:
+            title: 不透明性
       atmosphere:
         title: 大気
         description: 地球を覆う大気圏の設定ができます。

--- a/pkg/property/schema_field_ui.go
+++ b/pkg/property/schema_field_ui.go
@@ -7,6 +7,7 @@ const (
 	SchemaFieldUISelection  SchemaFieldUI = "selection"
 	SchemaFieldUIColor      SchemaFieldUI = "color"
 	SchemaFieldUIRange      SchemaFieldUI = "range"
+	SchemaFieldUISlider     SchemaFieldUI = "slider"
 	SchemaFieldUIImage      SchemaFieldUI = "image"
 	SchemaFieldUIVideo      SchemaFieldUI = "video"
 	SchemaFieldUIFile       SchemaFieldUI = "file"
@@ -21,6 +22,7 @@ var (
 		SchemaFieldUISelection,
 		SchemaFieldUIColor,
 		SchemaFieldUIRange,
+		SchemaFieldUISlider,
 		SchemaFieldUIImage,
 		SchemaFieldUIVideo,
 		SchemaFieldUIFile,

--- a/schema.graphql
+++ b/schema.graphql
@@ -471,6 +471,7 @@ enum PropertySchemaFieldUI {
   SELECTION
   COLOR
   RANGE
+  SLIDER
   IMAGE
   VIDEO
   FILE

--- a/schemas/plugin_manifest.json
+++ b/schemas/plugin_manifest.json
@@ -139,6 +139,7 @@
             "selection",
             "buttons",
             "range",
+            "slider",
             "image",
             "video",
             "file",


### PR DESCRIPTION
# Overview
closes reearth/reearth#278
Users want to be able to set an opacity to map tiles. So, this adds opacity to tiles :P 

## What I've done
Added slider as an option to schema ui in plugin_manifest
Added Opacity field to tile in manifest w min 0 and max 1, default 1.
Updated appropriate domain models, converters, etc

## How I tested
Checked if I could view field in UI, has default and can be changed.