### PR TITLE
test: add Mongo Asset's `FindByID` unit testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,11 @@ jobs:
   ci:
     name: CI
     runs-on: ubuntu-latest
+    services:
+      mongo:
+        image: mongo:4.4-focal
+        ports:
+          - 27017:27017
     steps:
       - name: set up
         uses: actions/setup-go@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
           args: --timeout=10m
       - name: test
         run: go test ./... -v -race -coverprofile=coverage.txt -covermode=atomic -timeout 10m
+        env:
+          REEARTH_DB: mongodb://localhost
       - name: Send coverage report
         uses: codecov/codecov-action@v2
         with:

--- a/internal/infrastructure/mongo/asset_test.go
+++ b/internal/infrastructure/mongo/asset_test.go
@@ -2,27 +2,15 @@ package mongo
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
-	"github.com/reearth/reearth-backend/internal/infrastructure/mongo/mongodoc"
 	"github.com/reearth/reearth-backend/pkg/asset"
 	"github.com/reearth/reearth-backend/pkg/id"
 	"github.com/stretchr/testify/assert"
-	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
-	"go.mongodb.org/mongo-driver/x/mongo/driver/uuid"
 )
 
 func TestFindByID(t *testing.T) {
-	// Skip unit testing if "REEARTH_DB" is not configured
-	// See details: https://github.com/reearth/reearth/issues/273
-	db := os.Getenv("REEARTH_DB")
-	if db == "" {
-		return
-	}
-
 	tests := []struct {
 		Name     string
 		Expected struct {
@@ -48,12 +36,7 @@ func TestFindByID(t *testing.T) {
 		},
 	}
 
-	c, _ := mongo.Connect(
-		context.Background(),
-		options.Client().
-			ApplyURI(db).
-			SetConnectTimeout(time.Second*10),
-	)
+	initDB := connect(t)
 
 	for _, tc := range tests {
 		tc := tc
@@ -61,17 +44,13 @@ func TestFindByID(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 
-			database, _ := uuid.New()
-			client := mongodoc.NewClient(string(database[:]), c)
-			repo := NewAsset(client)
+			client, dropDB := initDB()
+			defer dropDB()
 
+			repo := NewAsset(client)
 			ctx := context.Background()
 			err := repo.Save(ctx, tc.Expected.Asset)
 			assert.NoError(t, err)
-
-			defer func() {
-				_ = c.Database(string(database[:])).Drop(ctx)
-			}()
 
 			got, err := repo.FindByID(ctx, tc.Expected.Asset.ID())
 			assert.NoError(t, err)

--- a/internal/infrastructure/mongo/asset_test.go
+++ b/internal/infrastructure/mongo/asset_test.go
@@ -71,23 +71,21 @@ func TestFindByID(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 
-			want, err := asset.New().
+			want := asset.New().
 				NewID().
 				Team(tc.Expected.Asset.team).
 				Name(tc.Expected.Asset.name).
 				Size(tc.Expected.Asset.size).
 				URL(tc.Expected.Asset.url).
 				CreatedAt(tc.Expected.Asset.createdAt).
-				Build()
-
-			assert.NoError(t, err)
+				MustBuild()
 
 			database, _ := uuid.New()
 			client := mongodoc.NewClient(string(database[:]), c)
 			repo := NewAsset(client)
 
 			ctx := context.Background()
-			err = repo.Save(ctx, want)
+			err := repo.Save(ctx, want)
 			assert.NoError(t, err)
 
 			defer func() {

--- a/internal/infrastructure/mongo/asset_test.go
+++ b/internal/infrastructure/mongo/asset_test.go
@@ -1,0 +1,108 @@
+package mongo
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/reearth/reearth-backend/internal/infrastructure/mongo/mongodoc"
+	"github.com/reearth/reearth-backend/pkg/asset"
+	"github.com/reearth/reearth-backend/pkg/id"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/uuid"
+)
+
+func TestFindByID(t *testing.T) {
+	// Skip unit testing if "REEARTH_DB" is not configured
+	// See details: https://github.com/reearth/reearth/issues/273
+	db := os.Getenv("REEARTH_DB")
+	if db == "" {
+		return
+	}
+
+	type a struct {
+		id          asset.ID
+		createdAt   time.Time
+		team        asset.TeamID
+		name        string
+		size        int64
+		url         string
+		contentType string
+	}
+
+	tests := []struct {
+		Name     string
+		Expected struct {
+			Name  string
+			Asset *a
+		}
+	}{
+		{
+			Expected: struct {
+				Name  string
+				Asset *a
+			}{
+				Asset: &a{
+					id:          id.NewAssetID(),
+					createdAt:   time.Now(),
+					team:        id.NewTeamID(),
+					name:        "name",
+					size:        10,
+					url:         "hxxps://xxx.com",
+					contentType: "json",
+				},
+			},
+		},
+	}
+
+	c, _ := mongo.Connect(
+		context.Background(),
+		options.Client().
+			ApplyURI(db).
+			SetConnectTimeout(time.Second*10),
+	)
+
+	for _, tc := range tests {
+		tc := tc
+
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
+			want, err := asset.New().
+				NewID().
+				Team(tc.Expected.Asset.team).
+				Name(tc.Expected.Asset.name).
+				Size(tc.Expected.Asset.size).
+				URL(tc.Expected.Asset.url).
+				CreatedAt(tc.Expected.Asset.createdAt).
+				Build()
+
+			assert.NoError(t, err)
+
+			database, _ := uuid.New()
+			client := mongodoc.NewClient(string(database[:]), c)
+			repo := NewAsset(client)
+
+			ctx := context.Background()
+			err = repo.Save(ctx, want)
+			assert.NoError(t, err)
+
+			defer func() {
+				_ = c.Database(string(database[:])).Drop(ctx)
+			}()
+
+			got, err := repo.FindByID(ctx, want.ID())
+			assert.NoError(t, err)
+			assert.Equal(t, want.ID(), got.ID())
+			assert.Equal(t, want.CreatedAt(), got.CreatedAt())
+			assert.Equal(t, want.Team(), got.Team())
+			assert.Equal(t, want.URL(), got.URL())
+			assert.Equal(t, want.Size(), got.Size())
+			assert.Equal(t, want.Name(), got.Name())
+			assert.Equal(t, want.ContentType(), got.ContentType())
+		})
+	}
+}

--- a/internal/infrastructure/mongo/mongo_test.go
+++ b/internal/infrastructure/mongo/mongo_test.go
@@ -2,6 +2,7 @@ package mongo
 
 import (
 	"context"
+	"encoding/hex"
 	"os"
 	"testing"
 	"time"
@@ -32,7 +33,7 @@ func connect(t *testing.T) func() (*mongodoc.Client, func()) {
 
 	return func() (*mongodoc.Client, func()) {
 		database, _ := uuid.New()
-		databaseName := "reearth-test-" + string(database[:])
+		databaseName := "reearth-test-" + hex.EncodeToString(database[:])
 		client := mongodoc.NewClient(databaseName, c)
 
 		return client, func() {

--- a/internal/infrastructure/mongo/mongo_test.go
+++ b/internal/infrastructure/mongo/mongo_test.go
@@ -1,0 +1,42 @@
+package mongo
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/reearth/reearth-backend/internal/infrastructure/mongo/mongodoc"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/uuid"
+)
+
+func connect(t *testing.T) func() (*mongodoc.Client, func()) {
+	t.Helper()
+
+	// Skip unit testing if "REEARTH_DB" is not configured
+	// See details: https://github.com/reearth/reearth/issues/273
+	db := os.Getenv("REEARTH_DB")
+	if db == "" {
+		t.SkipNow()
+		return nil
+	}
+
+	c, _ := mongo.Connect(
+		context.Background(),
+		options.Client().
+			ApplyURI(db).
+			SetConnectTimeout(time.Second*10),
+	)
+
+	return func() (*mongodoc.Client, func()) {
+		database, _ := uuid.New()
+		databaseName := "reearth-test-" + string(database[:])
+		client := mongodoc.NewClient(databaseName, c)
+
+		return client, func() {
+			_ = c.Database(databaseName).Drop(context.Background())
+		}
+	}
+}


### PR DESCRIPTION
# Overview

I have added initial unit testing for the MongoDB based on this issue for "small start" 👉  https://github.com/reearth/reearth/issues/273.
See details (requirements) in that issue.

I implemented one for a trial to avoid conflicts and decide how we are going to test this methods.

## What I've done

I have added unit test for the Asset repository's `FindByID` method.

## What I haven't done

Add unit tests for all methods for Assets or other repositories.
This is because I wanted to "start small" since we need to discuss the policy and the implementation design first so that we don't waste time.

## How I tested

The testings are done by the CI GitHub Actions workflow.
This can be also tested locally.

```shell
# Skip testing
go test -timeout 30s -run '^TestFindByID$' github.com/reearth/reearth-backend/internal/infrastructure/mongo

# Test (after launching MongoDB instance in your local environment)
REEARTH_DB=mongodb://localhost go test -timeout 30s -run '^TestFindByID$' github.com/reearth/reearth-backend/internal/infrastructure/mongo
```

## Which point I want you to review particularly

* How the testing(s) should be done
    * Table testing
    * Variable namings
    * etc 

## Memo

Please feel free to give me any feedback as this is the starting point of adding unit tests to the repository layer.