### PR TITLE
ci: bump `actions/cache` to `v3`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
       - name: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}


### PR DESCRIPTION
# Overview

## What I've done

I have bumped the `actions/cache` GitHub Action to `v3`.

## What I haven't done

Modify any other things.

## How I tested

Ran the CI.

## Which point I want you to review particularly

Check nothing is broken.

## Memo

As far as I understand, there are no breaking changes in these version updates.

* Ref: [v3.0.0](https://github.com/actions/cache/releases/tag/v3.0.0)