### PR TITLE
fix: "$in needs an array" error from mongo FindByIDs

### DIFF
--- a/internal/infrastructure/mongo/asset.go
+++ b/internal/infrastructure/mongo/asset.go
@@ -41,6 +41,10 @@ func (r *assetRepo) FindByID(ctx context.Context, id id.AssetID) (*asset.Asset, 
 }
 
 func (r *assetRepo) FindByIDs(ctx context.Context, ids id.AssetIDList) ([]*asset.Asset, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
 	filter := bson.M{
 		"id": bson.M{"$in": ids.Strings()},
 	}

--- a/internal/infrastructure/mongo/dataset.go
+++ b/internal/infrastructure/mongo/dataset.go
@@ -46,6 +46,10 @@ func (r *datasetRepo) FindByID(ctx context.Context, id id.DatasetID) (*dataset.D
 }
 
 func (r *datasetRepo) FindByIDs(ctx context.Context, ids id.DatasetIDList) (dataset.List, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
 	filter := bson.M{
 		"id": bson.M{
 			"$in": ids.Strings(),

--- a/internal/infrastructure/mongo/dataset_schema.go
+++ b/internal/infrastructure/mongo/dataset_schema.go
@@ -46,6 +46,10 @@ func (r *datasetSchemaRepo) FindByID(ctx context.Context, id id.DatasetSchemaID)
 }
 
 func (r *datasetSchemaRepo) FindByIDs(ctx context.Context, ids id.DatasetSchemaIDList) (dataset.SchemaList, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
 	filter := bson.M{
 		"id": bson.M{
 			"$in": ids.Strings(),

--- a/internal/infrastructure/mongo/layer.go
+++ b/internal/infrastructure/mongo/layer.go
@@ -45,6 +45,10 @@ func (r *layerRepo) FindByID(ctx context.Context, id id.LayerID) (layer.Layer, e
 }
 
 func (r *layerRepo) FindByIDs(ctx context.Context, ids id.LayerIDList) (layer.List, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
 	filter := bson.M{
 		"id": bson.M{
 			"$in": ids.Strings(),

--- a/internal/infrastructure/mongo/plugin.go
+++ b/internal/infrastructure/mongo/plugin.go
@@ -54,6 +54,10 @@ func (r *pluginRepo) FindByID(ctx context.Context, pid id.PluginID) (*plugin.Plu
 }
 
 func (r *pluginRepo) FindByIDs(ctx context.Context, ids []id.PluginID) ([]*plugin.Plugin, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
 	// TODO: separate built-in plugins to another repository
 	// exclude built-in
 	b := plugin.Map{}

--- a/internal/infrastructure/mongo/project.go
+++ b/internal/infrastructure/mongo/project.go
@@ -39,7 +39,17 @@ func (r *projectRepo) Filtered(f repo.TeamFilter) repo.Project {
 	}
 }
 
+func (r *projectRepo) FindByID(ctx context.Context, id id.ProjectID) (*project.Project, error) {
+	return r.findOne(ctx, bson.M{
+		"id": id.String(),
+	})
+}
+
 func (r *projectRepo) FindByIDs(ctx context.Context, ids id.ProjectIDList) ([]*project.Project, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
 	filter := bson.M{
 		"id": bson.M{
 			"$in": ids.Strings(),
@@ -51,12 +61,6 @@ func (r *projectRepo) FindByIDs(ctx context.Context, ids id.ProjectIDList) ([]*p
 		return nil, err
 	}
 	return filterProjects(ids, res), nil
-}
-
-func (r *projectRepo) FindByID(ctx context.Context, id id.ProjectID) (*project.Project, error) {
-	return r.findOne(ctx, bson.M{
-		"id": id.String(),
-	})
 }
 
 func (r *projectRepo) FindByTeam(ctx context.Context, id id.TeamID, pagination *usecase.Pagination) ([]*project.Project, *usecase.PageInfo, error) {

--- a/internal/infrastructure/mongo/property.go
+++ b/internal/infrastructure/mongo/property.go
@@ -44,6 +44,10 @@ func (r *propertyRepo) FindByID(ctx context.Context, id id.PropertyID) (*propert
 }
 
 func (r *propertyRepo) FindByIDs(ctx context.Context, ids id.PropertyIDList) (property.List, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
 	filter := bson.M{
 		"id": bson.M{
 			"$in": ids.Strings(),

--- a/internal/infrastructure/mongo/property_schema.go
+++ b/internal/infrastructure/mongo/property_schema.go
@@ -48,6 +48,10 @@ func (r *propertySchemaRepo) FindByID(ctx context.Context, id id.PropertySchemaI
 }
 
 func (r *propertySchemaRepo) FindByIDs(ctx context.Context, ids []id.PropertySchemaID) (property.SchemaList, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
 	// exclude built-in
 	b := property.SchemaMap{}
 	ids2 := make([]id.PropertySchemaID, 0, len(ids))

--- a/internal/infrastructure/mongo/scene.go
+++ b/internal/infrastructure/mongo/scene.go
@@ -45,6 +45,10 @@ func (r *sceneRepo) FindByID(ctx context.Context, id id.SceneID) (*scene.Scene, 
 }
 
 func (r *sceneRepo) FindByIDs(ctx context.Context, ids id.SceneIDList) (scene.List, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
 	return r.find(ctx, make(scene.List, 0, len(ids)), bson.M{
 		"id": bson.M{
 			"$in": ids.Strings(),

--- a/internal/infrastructure/mongo/tag.go
+++ b/internal/infrastructure/mongo/tag.go
@@ -45,6 +45,10 @@ func (r *tagRepo) FindByID(ctx context.Context, id id.TagID) (tag.Tag, error) {
 }
 
 func (r *tagRepo) FindByIDs(ctx context.Context, ids id.TagIDList) ([]*tag.Tag, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
 	filter := bson.M{
 		"id": bson.M{
 			"$in": ids.Strings(),

--- a/internal/infrastructure/mongo/team.go
+++ b/internal/infrastructure/mongo/team.go
@@ -38,6 +38,10 @@ func (r *teamRepo) FindByUser(ctx context.Context, id id.UserID) (user.TeamList,
 }
 
 func (r *teamRepo) FindByIDs(ctx context.Context, ids id.TeamIDList) (user.TeamList, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
 	dst := make([]*user.Team, 0, len(ids))
 	res, err := r.find(ctx, dst, bson.M{
 		"id": bson.M{"$in": ids.Strings()},

--- a/internal/infrastructure/mongo/user.go
+++ b/internal/infrastructure/mongo/user.go
@@ -30,6 +30,10 @@ func (r *userRepo) init() {
 }
 
 func (r *userRepo) FindByIDs(ctx context.Context, ids id.UserIDList) ([]*user.User, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
 	dst := make([]*user.User, 0, len(ids))
 	res, err := r.find(ctx, dst, bson.M{
 		"id": bson.M{"$in": ids.Strings()},


### PR DESCRIPTION
## What I've done

An error "$in needs an array" returns from MongoDB when `ids` arg of `internal/infrastrucutre/mongo.*.FindByIDs` methods is nil.

## How I tested
