### PR TITLE
refactor: declarative description of use case structure (asset only)

### DIFF
--- a/internal/app/usecase.go
+++ b/internal/app/usecase.go
@@ -15,11 +15,10 @@ func UsecaseMiddleware(r *repo.Container, g *gateway.Container, config interacto
 		var r2 *repo.Container
 		if op := adapter.Operator(ctx); op != nil && r != nil {
 			// apply filters to repos
-			r3 := r.Filtered(
+			r2 = r.Filtered(
 				repo.TeamFilterFromOperator(op),
 				repo.SceneFilterFromOperator(op),
 			)
-			r2 = &r3
 		} else {
 			r2 = r
 		}

--- a/internal/infrastructure/memory/transaction_test.go
+++ b/internal/infrastructure/memory/transaction_test.go
@@ -1,0 +1,38 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTransaction_Committed(t *testing.T) {
+	tr := NewTransaction()
+	tx, err := tr.Begin()
+	assert.NoError(t, err)
+	assert.Equal(t, 0, tr.Committed())
+	tx.Commit()
+	assert.Equal(t, 1, tr.Committed())
+	assert.NoError(t, tx.End(context.Background()))
+	assert.NoError(t, err)
+}
+
+func TestTransaction_SetBeginError(t *testing.T) {
+	err := errors.New("a")
+	tr := NewTransaction()
+	tr.SetBeginError(err)
+	tx, err2 := tr.Begin()
+	assert.Nil(t, tx)
+	assert.Same(t, err, err2)
+}
+
+func TestTransaction_SetEndError(t *testing.T) {
+	err := errors.New("a")
+	tr := NewTransaction()
+	tr.SetEndError(err)
+	tx, err2 := tr.Begin()
+	assert.NoError(t, err2)
+	assert.Same(t, err, tx.End(context.Background()))
+}

--- a/internal/infrastructure/mongo/mongodoc/client.go
+++ b/internal/infrastructure/mongo/mongodoc/client.go
@@ -433,3 +433,7 @@ func (t *Tx) End(ctx context.Context) error {
 	t.session.EndSession(ctx)
 	return nil
 }
+
+func (t *Tx) IsCommitted() bool {
+	return t.commit
+}

--- a/internal/usecase/interactor/asset.go
+++ b/internal/usecase/interactor/asset.go
@@ -32,8 +32,8 @@ func (i *Asset) Fetch(ctx context.Context, assets []id.AssetID, operator *usecas
 func (i *Asset) FindByTeam(ctx context.Context, tid id.TeamID, keyword *string, sort *asset.SortType, p *usecase.Pagination, operator *usecase.Operator) ([]*asset.Asset, *usecase.PageInfo, error) {
 	return Run2(
 		ctx, operator, i.repos,
-		Usecase().CanReadTeams(tid),
-		func(ctx context.Context) ([]*asset.Asset, *usecase.PageInfo, error) {
+		Usecase().WithReadableTeams(tid),
+		func() ([]*asset.Asset, *usecase.PageInfo, error) {
 			return i.repos.Asset.FindByTeam(ctx, tid, repo.AssetFilter{
 				Sort:       sort,
 				Keyword:    keyword,
@@ -51,9 +51,9 @@ func (i *Asset) Create(ctx context.Context, inp interfaces.CreateAssetParam, ope
 	return Run1(
 		ctx, operator, i.repos,
 		Usecase().
-			CanReadTeams(inp.TeamID).
+			WithReadableTeams(inp.TeamID).
 			Transaction(),
-		func(ctx context.Context) (*asset.Asset, error) {
+		func() (*asset.Asset, error) {
 			url, err := i.gateways.File.UploadAsset(ctx, inp.File)
 			if err != nil {
 				return nil, err
@@ -73,7 +73,7 @@ func (i *Asset) Remove(ctx context.Context, aid id.AssetID, operator *usecase.Op
 	return Run1(
 		ctx, operator, i.repos,
 		Usecase().Transaction(),
-		func(ctx context.Context) (id.AssetID, error) {
+		func() (id.AssetID, error) {
 			asset, err := i.repos.Asset.FindByID(ctx, aid)
 			if err != nil {
 				return aid, err

--- a/internal/usecase/interactor/asset.go
+++ b/internal/usecase/interactor/asset.go
@@ -14,7 +14,6 @@ import (
 )
 
 type Asset struct {
-	common
 	repos    *repo.Container
 	gateways *gateway.Container
 }
@@ -31,95 +30,66 @@ func (i *Asset) Fetch(ctx context.Context, assets []id.AssetID, operator *usecas
 }
 
 func (i *Asset) FindByTeam(ctx context.Context, tid id.TeamID, keyword *string, sort *asset.SortType, p *usecase.Pagination, operator *usecase.Operator) ([]*asset.Asset, *usecase.PageInfo, error) {
-	if err := i.CanReadTeam(tid, operator); err != nil {
-		return nil, nil, err
-	}
-
-	return i.repos.Asset.FindByTeam(ctx, tid, repo.AssetFilter{
-		Sort:       sort,
-		Keyword:    keyword,
-		Pagination: p,
-	})
+	return Run2(
+		ctx, operator, i.repos,
+		Usecase().CanReadTeams(tid),
+		func(ctx context.Context) ([]*asset.Asset, *usecase.PageInfo, error) {
+			return i.repos.Asset.FindByTeam(ctx, tid, repo.AssetFilter{
+				Sort:       sort,
+				Keyword:    keyword,
+				Pagination: p,
+			})
+		},
+	)
 }
 
 func (i *Asset) Create(ctx context.Context, inp interfaces.CreateAssetParam, operator *usecase.Operator) (result *asset.Asset, err error) {
-	if err := i.CanWriteTeam(inp.TeamID, operator); err != nil {
-		return nil, err
-	}
-
 	if inp.File == nil {
 		return nil, interfaces.ErrFileNotIncluded
 	}
 
-	tx, err := i.repos.Transaction.Begin()
-	if err != nil {
-		return
-	}
-	defer func() {
-		if err2 := tx.End(ctx); err == nil && err2 != nil {
-			err = err2
-		}
-	}()
+	return Run1(
+		ctx, operator, i.repos,
+		Usecase().
+			CanReadTeams(inp.TeamID).
+			Transaction(),
+		func(ctx context.Context) (*asset.Asset, error) {
+			url, err := i.gateways.File.UploadAsset(ctx, inp.File)
+			if err != nil {
+				return nil, err
+			}
 
-	url, err := i.gateways.File.UploadAsset(ctx, inp.File)
-	if err != nil {
-		return nil, err
-	}
-
-	result, err = asset.New().
-		NewID().
-		Team(inp.TeamID).
-		Name(path.Base(inp.File.Path)).
-		Size(inp.File.Size).
-		URL(url.String()).
-		Build()
-	if err != nil {
-		return nil, err
-	}
-
-	if err = i.repos.Asset.Save(ctx, result); err != nil {
-		return
-	}
-
-	tx.Commit()
-	return
+			return asset.New().
+				NewID().
+				Team(inp.TeamID).
+				Name(path.Base(inp.File.Path)).
+				Size(inp.File.Size).
+				URL(url.String()).
+				Build()
+		})
 }
 
 func (i *Asset) Remove(ctx context.Context, aid id.AssetID, operator *usecase.Operator) (result id.AssetID, err error) {
-	asset, err := i.repos.Asset.FindByID(ctx, aid)
-	if err != nil {
-		return aid, err
-	}
+	return Run1(
+		ctx, operator, i.repos,
+		Usecase().Transaction(),
+		func(ctx context.Context) (id.AssetID, error) {
+			asset, err := i.repos.Asset.FindByID(ctx, aid)
+			if err != nil {
+				return aid, err
+			}
 
-	tx, err := i.repos.Transaction.Begin()
-	if err != nil {
-		return
-	}
-	defer func() {
-		if err2 := tx.End(ctx); err == nil && err2 != nil {
-			err = err2
-		}
-	}()
+			if ok := operator.IsWritableTeam(asset.Team()); !ok {
+				return aid, interfaces.ErrOperationDenied
+			}
 
-	team, err := i.repos.Team.FindByID(ctx, asset.Team())
-	if err != nil {
-		return aid, err
-	}
+			if url, _ := url.Parse(asset.URL()); url != nil {
+				if err := i.gateways.File.RemoveAsset(ctx, url); err != nil {
+					return aid, err
+				}
+			}
 
-	if !team.Members().ContainsUser(operator.User) {
-		return aid, interfaces.ErrOperationDenied
-	}
-
-	if url, _ := url.Parse(asset.URL()); url != nil {
-		if err = i.gateways.File.RemoveAsset(ctx, url); err != nil {
-			return aid, err
-		}
-	}
-
-	if err = i.repos.Asset.Remove(ctx, aid); err != nil {
-		return
-	}
-
-	tx.Commit()
-	return aid, nil
+			return aid, i.repos.Asset.Remove(ctx, aid)
+		},
+	)
 }

--- a/internal/usecase/interactor/common.go
+++ b/internal/usecase/interactor/common.go
@@ -45,7 +45,7 @@ func NewContainer(r *repo.Container, g *gateway.Container, config ContainerConfi
 	}
 }
 
-// common will be decrepated. Please use the Usecase function instead.
+// Deprecated: common will be deprecated. Please use the Usecase function instead.
 type common struct{}
 
 func (common) OnlyOperator(op *usecase.Operator) error {

--- a/internal/usecase/interactor/common.go
+++ b/internal/usecase/interactor/common.go
@@ -5,10 +5,9 @@ import (
 	"errors"
 	"net/url"
 
+	"github.com/reearth/reearth-backend/internal/usecase"
 	"github.com/reearth/reearth-backend/internal/usecase/gateway"
 	"github.com/reearth/reearth-backend/internal/usecase/interfaces"
-
-	"github.com/reearth/reearth-backend/internal/usecase"
 	"github.com/reearth/reearth-backend/internal/usecase/repo"
 	"github.com/reearth/reearth-backend/pkg/id"
 	"github.com/reearth/reearth-backend/pkg/project"
@@ -46,6 +45,7 @@ func NewContainer(r *repo.Container, g *gateway.Container, config ContainerConfi
 	}
 }
 
+// common will be decrepated. Please use the Usecase function instead.
 type common struct{}
 
 func (common) OnlyOperator(op *usecase.Operator) error {

--- a/internal/usecase/interactor/usecase.go
+++ b/internal/usecase/interactor/usecase.go
@@ -21,23 +21,23 @@ func Usecase() *uc {
 	return &uc{}
 }
 
-func (u *uc) CanReadTeams(ids ...id.TeamID) *uc {
-	u.readableTeams = ids
+func (u *uc) WithReadableTeams(ids ...id.TeamID) *uc {
+	u.readableTeams = id.TeamIDList(ids).Clone()
 	return u
 }
 
-func (u *uc) CanWriteTeams(ids ...id.TeamID) *uc {
-	u.writableTeams = ids
+func (u *uc) WithWritableTeams(ids ...id.TeamID) *uc {
+	u.writableTeams = id.TeamIDList(ids).Clone()
 	return u
 }
 
-func (u *uc) CanReadScenes(ids ...id.SceneID) *uc {
-	u.readableScenes = ids
+func (u *uc) WithReadablScenes(ids ...id.SceneID) *uc {
+	u.readableScenes = id.SceneIDList(ids).Clone()
 	return u
 }
 
-func (u *uc) CanWriteSceens(ids ...id.SceneID) *uc {
-	u.writableScenes = ids
+func (u *uc) WithWritableScenes(ids ...id.SceneID) *uc {
+	u.writableScenes = id.SceneIDList(ids).Clone()
 	return u
 }
 
@@ -46,37 +46,37 @@ func (u *uc) Transaction() *uc {
 	return u
 }
 
-func Run0(ctx context.Context, op *usecase.Operator, r *repo.Container, e *uc, f func(context.Context) error) (err error) {
+func Run0(ctx context.Context, op *usecase.Operator, r *repo.Container, e *uc, f func() error) (err error) {
 	_, _, _, err = Run3(
 		ctx, op, r, e,
-		func(ctx context.Context) (_, _, _ any, err error) {
-			err = f(ctx)
+		func() (_, _, _ any, err error) {
+			err = f()
 			return
 		})
 	return
 }
 
-func Run1[A any](ctx context.Context, op *usecase.Operator, r *repo.Container, e *uc, f func(context.Context) (A, error)) (a A, err error) {
+func Run1[A any](ctx context.Context, op *usecase.Operator, r *repo.Container, e *uc, f func() (A, error)) (a A, err error) {
 	a, _, _, err = Run3(
 		ctx, op, r, e,
-		func(ctx context.Context) (a A, _, _ any, err error) {
-			a, err = f(ctx)
+		func() (a A, _, _ any, err error) {
+			a, err = f()
 			return
 		})
 	return
 }
 
-func Run2[A, B any](ctx context.Context, op *usecase.Operator, r *repo.Container, e *uc, f func(context.Context) (A, B, error)) (a A, b B, err error) {
+func Run2[A, B any](ctx context.Context, op *usecase.Operator, r *repo.Container, e *uc, f func() (A, B, error)) (a A, b B, err error) {
 	a, b, _, err = Run3(
 		ctx, op, r, e,
-		func(ctx context.Context) (a A, b B, _ any, err error) {
-			a, b, err = f(ctx)
+		func() (a A, b B, _ any, err error) {
+			a, b, err = f()
 			return
 		})
 	return
 }
 
-func Run3[A, B, C any](ctx context.Context, op *usecase.Operator, r *repo.Container, e *uc, f func(context.Context) (A, B, C, error)) (_ A, _ B, _ C, err error) {
+func Run3[A, B, C any](ctx context.Context, op *usecase.Operator, r *repo.Container, e *uc, f func() (A, B, C, error)) (_ A, _ B, _ C, err error) {
 	if err = e.checkPermission(op); err != nil {
 		return
 	}
@@ -97,7 +97,7 @@ func Run3[A, B, C any](ctx context.Context, op *usecase.Operator, r *repo.Contai
 		}()
 	}
 
-	return f(ctx)
+	return f()
 }
 
 func (u *uc) checkPermission(op *usecase.Operator) error {

--- a/internal/usecase/interactor/usecase.go
+++ b/internal/usecase/interactor/usecase.go
@@ -1,0 +1,121 @@
+package interactor
+
+import (
+	"context"
+
+	"github.com/reearth/reearth-backend/internal/usecase"
+	"github.com/reearth/reearth-backend/internal/usecase/interfaces"
+	"github.com/reearth/reearth-backend/internal/usecase/repo"
+	"github.com/reearth/reearth-backend/pkg/id"
+)
+
+type uc struct {
+	tx             bool
+	readableTeams  id.TeamIDList
+	writableTeams  id.TeamIDList
+	readableScenes id.SceneIDList
+	writableScenes id.SceneIDList
+}
+
+func Usecase() *uc {
+	return &uc{}
+}
+
+func (u *uc) CanReadTeams(ids ...id.TeamID) *uc {
+	u.readableTeams = ids
+	return u
+}
+
+func (u *uc) CanWriteTeams(ids ...id.TeamID) *uc {
+	u.writableTeams = ids
+	return u
+}
+
+func (u *uc) CanReadScenes(ids ...id.SceneID) *uc {
+	u.readableScenes = ids
+	return u
+}
+
+func (u *uc) CanWriteSceens(ids ...id.SceneID) *uc {
+	u.writableScenes = ids
+	return u
+}
+
+func (u *uc) Transaction() *uc {
+	u.tx = true
+	return u
+}
+
+func Run0(ctx context.Context, op *usecase.Operator, r *repo.Container, e *uc, f func(context.Context) error) (err error) {
+	_, _, _, err = Run3(
+		ctx, op, r, e,
+		func(ctx context.Context) (_, _, _ any, err error) {
+			err = f(ctx)
+			return
+		})
+	return
+}
+
+func Run1[A any](ctx context.Context, op *usecase.Operator, r *repo.Container, e *uc, f func(context.Context) (A, error)) (a A, err error) {
+	a, _, _, err = Run3(
+		ctx, op, r, e,
+		func(ctx context.Context) (a A, _, _ any, err error) {
+			a, err = f(ctx)
+			return
+		})
+	return
+}
+
+func Run2[A, B any](ctx context.Context, op *usecase.Operator, r *repo.Container, e *uc, f func(context.Context) (A, B, error)) (a A, b B, err error) {
+	a, b, _, err = Run3(
+		ctx, op, r, e,
+		func(ctx context.Context) (a A, b B, _ any, err error) {
+			a, b, err = f(ctx)
+			return
+		})
+	return
+}
+
+func Run3[A, B, C any](ctx context.Context, op *usecase.Operator, r *repo.Container, e *uc, f func(context.Context) (A, B, C, error)) (_ A, _ B, _ C, err error) {
+	if err = e.checkPermission(op); err != nil {
+		return
+	}
+
+	if e.tx && r.Transaction != nil {
+		tx, err2 := r.Transaction.Begin()
+		if err2 != nil {
+			err = err2
+			return
+		}
+		defer func() {
+			if err == nil {
+				tx.Commit()
+			}
+			if err2 := tx.End(ctx); err == nil && err2 != nil {
+				err = err2
+			}
+		}()
+	}
+
+	return f(ctx)
+}
+
+func (u *uc) checkPermission(op *usecase.Operator) error {
+	ok := true
+	if u.readableTeams != nil {
+		ok = op.IsReadableTeam(u.readableTeams...)
+	}
+	if ok && u.writableTeams != nil {
+		ok = op.IsWritableTeam(u.writableTeams...)
+	}
+	if ok && u.readableScenes != nil {
+		ok = op.IsReadableScene(u.readableScenes...)
+	}
+	if ok && u.writableScenes != nil {
+		ok = op.IsWritableScene(u.writableScenes...)
+	}
+	if !ok {
+		return interfaces.ErrOperationDenied
+	}
+	return nil
+}

--- a/internal/usecase/interactor/usecase_test.go
+++ b/internal/usecase/interactor/usecase_test.go
@@ -121,6 +121,17 @@ func TestUc_checkPermission(t *testing.T) {
 	}
 }
 
+func TestUc(t *testing.T) {
+	teams := id.TeamIDList{id.NewTeamID(), id.NewTeamID(), id.NewTeamID()}
+	scenes := id.SceneIDList{id.NewSceneID(), id.NewSceneID(), id.NewSceneID()}
+	assert.Equal(t, &uc{}, Usecase())
+	assert.Equal(t, &uc{readableTeams: teams}, (&uc{}).WithReadableTeams(teams...))
+	assert.Equal(t, &uc{writableTeams: teams}, (&uc{}).WithWritableTeams(teams...))
+	assert.Equal(t, &uc{readableScenes: scenes}, (&uc{}).WithReadablScenes(scenes...))
+	assert.Equal(t, &uc{writableScenes: scenes}, (&uc{}).WithWritableScenes(scenes...))
+	assert.Equal(t, &uc{tx: true}, (&uc{}).Transaction())
+}
+
 func TestRun(t *testing.T) {
 	ctx := context.Background()
 	err := errors.New("test")
@@ -132,8 +143,7 @@ func TestRun(t *testing.T) {
 	gota, gotb, gotc, goterr := Run3(
 		ctx, nil, r,
 		Usecase(),
-		func(ctx2 context.Context) (any, any, any, error) {
-			assert.Same(t, ctx2, ctx)
+		func() (any, any, any, error) {
 			return a, b, c, nil
 		},
 	)
@@ -147,7 +157,7 @@ func TestRun(t *testing.T) {
 	_ = Run0(
 		ctx, nil, r,
 		Usecase().Transaction(),
-		func(ctx2 context.Context) error {
+		func() error {
 			return nil
 		},
 	)
@@ -157,7 +167,7 @@ func TestRun(t *testing.T) {
 	goterr = Run0(
 		ctx, nil, r,
 		Usecase().Transaction(),
-		func(ctx2 context.Context) error {
+		func() error {
 			return err
 		},
 	)
@@ -170,7 +180,7 @@ func TestRun(t *testing.T) {
 	goterr = Run0(
 		ctx, nil, r,
 		Usecase().Transaction(),
-		func(ctx2 context.Context) error {
+		func() error {
 			return nil
 		},
 	)
@@ -183,7 +193,7 @@ func TestRun(t *testing.T) {
 	goterr = Run0(
 		ctx, nil, r,
 		Usecase().Transaction(),
-		func(ctx2 context.Context) error {
+		func() error {
 			return nil
 		},
 	)

--- a/internal/usecase/interactor/usecase_test.go
+++ b/internal/usecase/interactor/usecase_test.go
@@ -1,0 +1,192 @@
+package interactor
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/reearth/reearth-backend/internal/infrastructure/memory"
+	"github.com/reearth/reearth-backend/internal/usecase"
+	"github.com/reearth/reearth-backend/internal/usecase/interfaces"
+	"github.com/reearth/reearth-backend/internal/usecase/repo"
+	"github.com/reearth/reearth-backend/pkg/id"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUc_checkPermission(t *testing.T) {
+	tid := id.NewTeamID()
+	sid := id.NewSceneID()
+
+	tests := []struct {
+		name           string
+		op             *usecase.Operator
+		readableTeams  id.TeamIDList
+		writableTeams  id.TeamIDList
+		readableScenes id.SceneIDList
+		writableScenes id.SceneIDList
+		wantErr        bool
+	}{
+		{
+			name:    "nil operator",
+			wantErr: false,
+		},
+		{
+			name:          "nil operator 2",
+			readableTeams: id.TeamIDList{id.NewTeamID()},
+			wantErr:       false,
+		},
+		{
+			name:          "can read a team",
+			readableTeams: id.TeamIDList{tid},
+			op: &usecase.Operator{
+				ReadableTeams: id.TeamIDList{tid},
+			},
+			wantErr: true,
+		},
+		{
+			name:          "cannot read a team",
+			readableTeams: id.TeamIDList{id.NewTeamID()},
+			op: &usecase.Operator{
+				ReadableTeams: id.TeamIDList{},
+			},
+			wantErr: true,
+		},
+		{
+			name:          "can write a team",
+			writableTeams: id.TeamIDList{tid},
+			op: &usecase.Operator{
+				WritableTeams: id.TeamIDList{tid},
+			},
+			wantErr: true,
+		},
+		{
+			name:          "cannot write a team",
+			writableTeams: id.TeamIDList{tid},
+			op: &usecase.Operator{
+				WritableTeams: id.TeamIDList{},
+			},
+			wantErr: true,
+		},
+		{
+			name:           "can read a scene",
+			readableScenes: id.SceneIDList{sid},
+			op: &usecase.Operator{
+				ReadableScenes: id.SceneIDList{sid},
+			},
+			wantErr: true,
+		},
+		{
+			name:           "cannot read a scene",
+			readableScenes: id.SceneIDList{sid},
+			op: &usecase.Operator{
+				ReadableScenes: id.SceneIDList{},
+			},
+			wantErr: true,
+		},
+		{
+			name:           "can write a scene",
+			writableScenes: id.SceneIDList{sid},
+			op: &usecase.Operator{
+				WritableScenes: id.SceneIDList{sid},
+			},
+			wantErr: true,
+		},
+		{
+			name:           "cannot write a scene",
+			writableScenes: id.SceneIDList{sid},
+			op: &usecase.Operator{
+				WritableScenes: id.SceneIDList{},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			e := &uc{
+				readableTeams:  tt.readableTeams,
+				writableTeams:  tt.writableTeams,
+				readableScenes: tt.readableScenes,
+				writableScenes: tt.writableScenes,
+			}
+			got := e.checkPermission(tt.op)
+			if tt.wantErr {
+				assert.Equal(t, interfaces.ErrOperationDenied, got)
+			} else {
+				assert.Nil(t, got)
+			}
+		})
+	}
+}
+
+func TestRun(t *testing.T) {
+	ctx := context.Background()
+	err := errors.New("test")
+	a, b, c := &struct{}{}, &struct{}{}, &struct{}{}
+	tr := memory.NewTransaction()
+	r := &repo.Container{Transaction: tr}
+
+	// regular1: without tx
+	gota, gotb, gotc, goterr := Run3(
+		ctx, nil, r,
+		Usecase(),
+		func(ctx2 context.Context) (any, any, any, error) {
+			assert.Same(t, ctx2, ctx)
+			return a, b, c, nil
+		},
+	)
+	assert.Same(t, a, gota)
+	assert.Same(t, b, gotb)
+	assert.Same(t, c, gotc)
+	assert.Nil(t, goterr)
+	assert.Equal(t, 0, tr.Committed()) // not committed
+
+	// regular2: with tx
+	_ = Run0(
+		ctx, nil, r,
+		Usecase().Transaction(),
+		func(ctx2 context.Context) error {
+			return nil
+		},
+	)
+	assert.Equal(t, 1, tr.Committed()) // committed
+
+	// iregular1: the usecase returns an error
+	goterr = Run0(
+		ctx, nil, r,
+		Usecase().Transaction(),
+		func(ctx2 context.Context) error {
+			return err
+		},
+	)
+	assert.Same(t, err, goterr)
+	assert.Equal(t, 1, tr.Committed()) // not committed
+
+	// iregular2: tx.Begin returns an error
+	tr.SetBeginError(err)
+	tr.SetEndError(nil)
+	goterr = Run0(
+		ctx, nil, r,
+		Usecase().Transaction(),
+		func(ctx2 context.Context) error {
+			return nil
+		},
+	)
+	assert.Same(t, err, goterr)
+	assert.Equal(t, 1, tr.Committed()) // not committed
+
+	// iregular3: tx.End returns an error
+	tr.SetBeginError(nil)
+	tr.SetEndError(err)
+	goterr = Run0(
+		ctx, nil, r,
+		Usecase().Transaction(),
+		func(ctx2 context.Context) error {
+			return nil
+		},
+	)
+	assert.Same(t, err, goterr)
+	assert.Equal(t, 2, tr.Committed()) // committed but fails
+}

--- a/internal/usecase/repo/container.go
+++ b/internal/usecase/repo/container.go
@@ -32,8 +32,11 @@ type Container struct {
 	User           User
 }
 
-func (c Container) Filtered(team TeamFilter, scene SceneFilter) Container {
-	return Container{
+func (c *Container) Filtered(team TeamFilter, scene SceneFilter) *Container {
+	if c == nil {
+		return c
+	}
+	return &Container{
 		Asset:          c.Asset.Filtered(team),
 		AuthRequest:    c.AuthRequest,
 		Config:         c.Config,

--- a/internal/usecase/repo/transaction.go
+++ b/internal/usecase/repo/transaction.go
@@ -13,4 +13,5 @@ type Tx interface {
 	// End finishes the transaction and do commit if Commit() was called once, or else do rollback.
 	// This method is supposed to be called in the uscase layer using defer.
 	End(context.Context) error
+	IsCommitted() bool
 }


### PR DESCRIPTION
Due to the low readability of use cases, the following statements can be made more declarative:

- Whether the usecase uses a transaction
- Whether the usecase denies users who cannot read/write the specific scene and team