### PR TITLE
refactor: update scene mode key

### DIFF
--- a/pkg/builtin/manifest.yml
+++ b/pkg/builtin/manifest.yml
@@ -82,7 +82,7 @@ extensions:
               type: string
               title: Scene mode
               description: Specify scene mode.
-              defaultValue: scene3d
+              defaultValue: 3d
               choices:
                 - key: 3d
                   label: Scene 3D

--- a/pkg/builtin/manifest.yml
+++ b/pkg/builtin/manifest.yml
@@ -84,9 +84,9 @@ extensions:
               description: Specify scene mode.
               defaultValue: scene3d
               choices:
-                - key: scene3d
+                - key: 3d
                   label: Scene 3D
-                - key: scene2d
+                - key: 2d
                   label: Scene 2D
                 - key: columbus
                   label: Columbus View


### PR DESCRIPTION
# Overview

Key and default value updates required by https://github.com/reearth/reearth-web/pull/228
This property has not been used except tests so should take no effects on former projects.

## What I've done

update `scene3d` to `3d`
update `scene2d` to `2d`
