### PR TITLE
feat: add totalCount field to DatasetSchema type of GraphQL schema

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -27,3 +27,7 @@ models:
     model: github.com/reearth/reearth-backend/internal/adapter/gql/gqlmodel.Lang
   ID:
     model: github.com/reearth/reearth-backend/internal/adapter/gql/gqlmodel.ID
+  DatasetSchema:
+    fields:
+      totalCount:
+        resolver: true

--- a/internal/adapter/gql/generated.go
+++ b/internal/adapter/gql/generated.go
@@ -246,6 +246,7 @@ type ComplexityRoot struct {
 		Scene                 func(childComplexity int) int
 		SceneID               func(childComplexity int) int
 		Source                func(childComplexity int) int
+		TotalCount            func(childComplexity int) int
 	}
 
 	DatasetSchemaConnection struct {
@@ -1080,6 +1081,8 @@ type DatasetFieldResolver interface {
 	ValueRef(ctx context.Context, obj *gqlmodel.DatasetField) (*gqlmodel.Dataset, error)
 }
 type DatasetSchemaResolver interface {
+	TotalCount(ctx context.Context, obj *gqlmodel.DatasetSchema) (int, error)
+
 	Datasets(ctx context.Context, obj *gqlmodel.DatasetSchema, first *int, last *int, after *usecase.Cursor, before *usecase.Cursor) (*gqlmodel.DatasetConnection, error)
 	Scene(ctx context.Context, obj *gqlmodel.DatasetSchema) (*gqlmodel.Scene, error)
 	RepresentativeField(ctx context.Context, obj *gqlmodel.DatasetSchema) (*gqlmodel.DatasetSchemaField, error)
@@ -1937,6 +1940,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.DatasetSchema.Source(childComplexity), true
+
+	case "DatasetSchema.totalCount":
+		if e.complexity.DatasetSchema.TotalCount == nil {
+			break
+		}
+
+		return e.complexity.DatasetSchema.TotalCount(childComplexity), true
 
 	case "DatasetSchemaConnection.edges":
 		if e.complexity.DatasetSchemaConnection.Edges == nil {
@@ -6906,6 +6916,7 @@ type DatasetSchema implements Node {
   name: String!
   sceneId: ID!
   fields: [DatasetSchemaField!]!
+  totalCount: Int!
   representativeFieldId: ID
   dynamic: Boolean
   datasets(
@@ -9929,6 +9940,8 @@ func (ec *executionContext) fieldContext_AddDatasetSchemaPayload_datasetSchema(c
 				return ec.fieldContext_DatasetSchema_sceneId(ctx, field)
 			case "fields":
 				return ec.fieldContext_DatasetSchema_fields(ctx, field)
+			case "totalCount":
+				return ec.fieldContext_DatasetSchema_totalCount(ctx, field)
 			case "representativeFieldId":
 				return ec.fieldContext_DatasetSchema_representativeFieldId(ctx, field)
 			case "dynamic":
@@ -9992,6 +10005,8 @@ func (ec *executionContext) fieldContext_AddDynamicDatasetPayload_datasetSchema(
 				return ec.fieldContext_DatasetSchema_sceneId(ctx, field)
 			case "fields":
 				return ec.fieldContext_DatasetSchema_fields(ctx, field)
+			case "totalCount":
+				return ec.fieldContext_DatasetSchema_totalCount(ctx, field)
 			case "representativeFieldId":
 				return ec.fieldContext_DatasetSchema_representativeFieldId(ctx, field)
 			case "dynamic":
@@ -10110,6 +10125,8 @@ func (ec *executionContext) fieldContext_AddDynamicDatasetSchemaPayload_datasetS
 				return ec.fieldContext_DatasetSchema_sceneId(ctx, field)
 			case "fields":
 				return ec.fieldContext_DatasetSchema_fields(ctx, field)
+			case "totalCount":
+				return ec.fieldContext_DatasetSchema_totalCount(ctx, field)
 			case "representativeFieldId":
 				return ec.fieldContext_DatasetSchema_representativeFieldId(ctx, field)
 			case "dynamic":
@@ -12835,6 +12852,8 @@ func (ec *executionContext) fieldContext_Dataset_schema(ctx context.Context, fie
 				return ec.fieldContext_DatasetSchema_sceneId(ctx, field)
 			case "fields":
 				return ec.fieldContext_DatasetSchema_fields(ctx, field)
+			case "totalCount":
+				return ec.fieldContext_DatasetSchema_totalCount(ctx, field)
 			case "representativeFieldId":
 				return ec.fieldContext_DatasetSchema_representativeFieldId(ctx, field)
 			case "dynamic":
@@ -13461,6 +13480,8 @@ func (ec *executionContext) fieldContext_DatasetField_schema(ctx context.Context
 				return ec.fieldContext_DatasetSchema_sceneId(ctx, field)
 			case "fields":
 				return ec.fieldContext_DatasetSchema_fields(ctx, field)
+			case "totalCount":
+				return ec.fieldContext_DatasetSchema_totalCount(ctx, field)
 			case "representativeFieldId":
 				return ec.fieldContext_DatasetSchema_representativeFieldId(ctx, field)
 			case "dynamic":
@@ -13825,6 +13846,50 @@ func (ec *executionContext) fieldContext_DatasetSchema_fields(ctx context.Contex
 				return ec.fieldContext_DatasetSchemaField_ref(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type DatasetSchemaField", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DatasetSchema_totalCount(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.DatasetSchema) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DatasetSchema_totalCount(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.DatasetSchema().TotalCount(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DatasetSchema_totalCount(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DatasetSchema",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
 		},
 	}
 	return fc, nil
@@ -14216,6 +14281,8 @@ func (ec *executionContext) fieldContext_DatasetSchemaConnection_nodes(ctx conte
 				return ec.fieldContext_DatasetSchema_sceneId(ctx, field)
 			case "fields":
 				return ec.fieldContext_DatasetSchema_fields(ctx, field)
+			case "totalCount":
+				return ec.fieldContext_DatasetSchema_totalCount(ctx, field)
 			case "representativeFieldId":
 				return ec.fieldContext_DatasetSchema_representativeFieldId(ctx, field)
 			case "dynamic":
@@ -14421,6 +14488,8 @@ func (ec *executionContext) fieldContext_DatasetSchemaEdge_node(ctx context.Cont
 				return ec.fieldContext_DatasetSchema_sceneId(ctx, field)
 			case "fields":
 				return ec.fieldContext_DatasetSchema_fields(ctx, field)
+			case "totalCount":
+				return ec.fieldContext_DatasetSchema_totalCount(ctx, field)
 			case "representativeFieldId":
 				return ec.fieldContext_DatasetSchema_representativeFieldId(ctx, field)
 			case "dynamic":
@@ -14745,6 +14814,8 @@ func (ec *executionContext) fieldContext_DatasetSchemaField_schema(ctx context.C
 				return ec.fieldContext_DatasetSchema_sceneId(ctx, field)
 			case "fields":
 				return ec.fieldContext_DatasetSchema_fields(ctx, field)
+			case "totalCount":
+				return ec.fieldContext_DatasetSchema_totalCount(ctx, field)
 			case "representativeFieldId":
 				return ec.fieldContext_DatasetSchema_representativeFieldId(ctx, field)
 			case "dynamic":
@@ -14808,6 +14879,8 @@ func (ec *executionContext) fieldContext_DatasetSchemaField_ref(ctx context.Cont
 				return ec.fieldContext_DatasetSchema_sceneId(ctx, field)
 			case "fields":
 				return ec.fieldContext_DatasetSchema_fields(ctx, field)
+			case "totalCount":
+				return ec.fieldContext_DatasetSchema_totalCount(ctx, field)
 			case "representativeFieldId":
 				return ec.fieldContext_DatasetSchema_representativeFieldId(ctx, field)
 			case "dynamic":
@@ -15110,6 +15183,8 @@ func (ec *executionContext) fieldContext_ImportDatasetPayload_datasetSchema(ctx 
 				return ec.fieldContext_DatasetSchema_sceneId(ctx, field)
 			case "fields":
 				return ec.fieldContext_DatasetSchema_fields(ctx, field)
+			case "totalCount":
+				return ec.fieldContext_DatasetSchema_totalCount(ctx, field)
 			case "representativeFieldId":
 				return ec.fieldContext_DatasetSchema_representativeFieldId(ctx, field)
 			case "dynamic":
@@ -17938,6 +18013,8 @@ func (ec *executionContext) fieldContext_LayerGroup_linkedDatasetSchema(ctx cont
 				return ec.fieldContext_DatasetSchema_sceneId(ctx, field)
 			case "fields":
 				return ec.fieldContext_DatasetSchema_fields(ctx, field)
+			case "totalCount":
+				return ec.fieldContext_DatasetSchema_totalCount(ctx, field)
 			case "representativeFieldId":
 				return ec.fieldContext_DatasetSchema_representativeFieldId(ctx, field)
 			case "dynamic":
@@ -31542,6 +31619,8 @@ func (ec *executionContext) fieldContext_PropertyFieldLink_datasetSchema(ctx con
 				return ec.fieldContext_DatasetSchema_sceneId(ctx, field)
 			case "fields":
 				return ec.fieldContext_DatasetSchema_fields(ctx, field)
+			case "totalCount":
+				return ec.fieldContext_DatasetSchema_totalCount(ctx, field)
 			case "representativeFieldId":
 				return ec.fieldContext_DatasetSchema_representativeFieldId(ctx, field)
 			case "dynamic":
@@ -35374,6 +35453,8 @@ func (ec *executionContext) fieldContext_Query_dynamicDatasetSchemas(ctx context
 				return ec.fieldContext_DatasetSchema_sceneId(ctx, field)
 			case "fields":
 				return ec.fieldContext_DatasetSchema_fields(ctx, field)
+			case "totalCount":
+				return ec.fieldContext_DatasetSchema_totalCount(ctx, field)
 			case "representativeFieldId":
 				return ec.fieldContext_DatasetSchema_representativeFieldId(ctx, field)
 			case "dynamic":
@@ -37160,6 +37241,8 @@ func (ec *executionContext) fieldContext_Scene_dynamicDatasetSchemas(ctx context
 				return ec.fieldContext_DatasetSchema_sceneId(ctx, field)
 			case "fields":
 				return ec.fieldContext_DatasetSchema_fields(ctx, field)
+			case "totalCount":
+				return ec.fieldContext_DatasetSchema_totalCount(ctx, field)
 			case "representativeFieldId":
 				return ec.fieldContext_DatasetSchema_representativeFieldId(ctx, field)
 			case "dynamic":
@@ -38597,6 +38680,8 @@ func (ec *executionContext) fieldContext_SyncDatasetPayload_datasetSchema(ctx co
 				return ec.fieldContext_DatasetSchema_sceneId(ctx, field)
 			case "fields":
 				return ec.fieldContext_DatasetSchema_fields(ctx, field)
+			case "totalCount":
+				return ec.fieldContext_DatasetSchema_totalCount(ctx, field)
 			case "representativeFieldId":
 				return ec.fieldContext_DatasetSchema_representativeFieldId(ctx, field)
 			case "dynamic":
@@ -39382,6 +39467,8 @@ func (ec *executionContext) fieldContext_TagItem_linkedDatasetSchema(ctx context
 				return ec.fieldContext_DatasetSchema_sceneId(ctx, field)
 			case "fields":
 				return ec.fieldContext_DatasetSchema_fields(ctx, field)
+			case "totalCount":
+				return ec.fieldContext_DatasetSchema_totalCount(ctx, field)
 			case "representativeFieldId":
 				return ec.fieldContext_DatasetSchema_representativeFieldId(ctx, field)
 			case "dynamic":
@@ -40705,6 +40792,8 @@ func (ec *executionContext) fieldContext_UpdateDatasetSchemaPayload_datasetSchem
 				return ec.fieldContext_DatasetSchema_sceneId(ctx, field)
 			case "fields":
 				return ec.fieldContext_DatasetSchema_fields(ctx, field)
+			case "totalCount":
+				return ec.fieldContext_DatasetSchema_totalCount(ctx, field)
 			case "representativeFieldId":
 				return ec.fieldContext_DatasetSchema_representativeFieldId(ctx, field)
 			case "dynamic":
@@ -48427,6 +48516,26 @@ func (ec *executionContext) _DatasetSchema(ctx context.Context, sel ast.Selectio
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
+		case "totalCount":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._DatasetSchema_totalCount(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return innerFunc(ctx)
+
+			})
 		case "representativeFieldId":
 
 			out.Values[i] = ec._DatasetSchema_representativeFieldId(ctx, field, obj)

--- a/internal/adapter/gql/gqlmodel/models_gen.go
+++ b/internal/adapter/gql/gqlmodel/models_gen.go
@@ -316,6 +316,7 @@ type DatasetSchema struct {
 	Name                  string                `json:"name"`
 	SceneID               ID                    `json:"sceneId"`
 	Fields                []*DatasetSchemaField `json:"fields"`
+	TotalCount            int                   `json:"totalCount"`
 	RepresentativeFieldID *ID                   `json:"representativeFieldId"`
 	Dynamic               *bool                 `json:"dynamic"`
 	Datasets              *DatasetConnection    `json:"datasets"`

--- a/internal/adapter/gql/loader_dataset.go
+++ b/internal/adapter/gql/loader_dataset.go
@@ -177,6 +177,20 @@ func (c *DatasetLoader) FindBySchema(ctx context.Context, dsid gqlmodel.ID, firs
 	return conn, nil
 }
 
+func (c *DatasetLoader) CountBySchema(ctx context.Context, dsid gqlmodel.ID) (int, error) {
+	id, err := gqlmodel.ToID[id.DatasetSchema](dsid)
+	if err != nil {
+		return 0, err
+	}
+
+	cnt, err := c.usecase.CountBySchema(ctx, id)
+	if err != nil {
+		return 0, err
+	}
+
+	return cnt, nil
+}
+
 // data loader
 
 type DatasetDataLoader interface {

--- a/internal/adapter/gql/resolver_dataset_schema.go
+++ b/internal/adapter/gql/resolver_dataset_schema.go
@@ -38,6 +38,10 @@ func (r *datasetSchemaResolver) Datasets(ctx context.Context, obj *gqlmodel.Data
 	return loaders(ctx).Dataset.FindBySchema(ctx, obj.ID, first, last, before, after)
 }
 
+func (r *datasetSchemaResolver) TotalCount(ctx context.Context, obj *gqlmodel.DatasetSchema) (int, error) {
+	return loaders(ctx).Dataset.CountBySchema(ctx, obj.ID)
+}
+
 type datasetSchemaFieldResolver struct{ *Resolver }
 
 func (r *datasetSchemaFieldResolver) Schema(ctx context.Context, obj *gqlmodel.DatasetSchemaField) (*gqlmodel.DatasetSchema, error) {

--- a/internal/infrastructure/memory/dataset.go
+++ b/internal/infrastructure/memory/dataset.go
@@ -87,6 +87,21 @@ func (r *Dataset) FindBySchema(ctx context.Context, id id.DatasetSchemaID, p *us
 	), nil
 }
 
+func (r *Dataset) CountBySchema(ctx context.Context, id id.DatasetSchemaID) (int, error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	n := dataset.List{}
+	for _, dataset := range r.data {
+		if dataset.Schema() == id {
+			if r.f.CanRead(dataset.Scene()) {
+				n = append(n, dataset)
+			}
+		}
+	}
+	return len(n), nil
+}
+
 func (r *Dataset) FindBySchemaAll(ctx context.Context, id id.DatasetSchemaID) (dataset.List, error) {
 	r.lock.Lock()
 	defer r.lock.Unlock()

--- a/internal/infrastructure/memory/dataset.go
+++ b/internal/infrastructure/memory/dataset.go
@@ -91,15 +91,15 @@ func (r *Dataset) CountBySchema(ctx context.Context, id id.DatasetSchemaID) (int
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	n := dataset.List{}
+	n := 0
 	for _, dataset := range r.data {
 		if dataset.Schema() == id {
 			if r.f.CanRead(dataset.Scene()) {
-				n = append(n, dataset)
+				n++
 			}
 		}
 	}
-	return len(n), nil
+	return n, nil
 }
 
 func (r *Dataset) FindBySchemaAll(ctx context.Context, id id.DatasetSchemaID) (dataset.List, error) {

--- a/internal/infrastructure/mongo/dataset.go
+++ b/internal/infrastructure/mongo/dataset.go
@@ -69,6 +69,16 @@ func (r *datasetRepo) FindBySchema(ctx context.Context, schemaID id.DatasetSchem
 	}, pagination)
 }
 
+func (r *datasetRepo) CountBySchema(ctx context.Context, id id.DatasetSchemaID) (int, error) {
+	res, err := r.client.Count(ctx, bson.M{
+		"schema": id.String(),
+	})
+	if err != nil {
+		return 0, err
+	}
+	return int(res), nil
+}
+
 func (r *datasetRepo) FindBySchemaAll(ctx context.Context, schemaID id.DatasetSchemaID) (dataset.List, error) {
 	return r.find(ctx, nil, bson.M{
 		"schema": schemaID.String(),

--- a/internal/infrastructure/mongo/dataset.go
+++ b/internal/infrastructure/mongo/dataset.go
@@ -70,9 +70,9 @@ func (r *datasetRepo) FindBySchema(ctx context.Context, schemaID id.DatasetSchem
 }
 
 func (r *datasetRepo) CountBySchema(ctx context.Context, id id.DatasetSchemaID) (int, error) {
-	res, err := r.client.Count(ctx, bson.M{
+	res, err := r.client.Count(ctx, r.readFilter(bson.M{
 		"schema": id.String(),
-	})
+	}))
 	if err != nil {
 		return 0, err
 	}

--- a/internal/usecase/interactor/dataset.go
+++ b/internal/usecase/interactor/dataset.go
@@ -405,6 +405,10 @@ func (i *Dataset) FindBySchema(ctx context.Context, ds id.DatasetSchemaID, p *us
 	return i.datasetRepo.FindBySchema(ctx, ds, p)
 }
 
+func (i *Dataset) CountBySchema(ctx context.Context, id id.DatasetSchemaID) (int, error) {
+	return i.datasetRepo.CountBySchema(ctx, id)
+}
+
 func (i *Dataset) FindSchemaByScene(ctx context.Context, sid id.SceneID, p *usecase.Pagination, operator *usecase.Operator) (dataset.SchemaList, *usecase.PageInfo, error) {
 	if err := i.CanReadScene(sid, operator); err != nil {
 		return nil, nil, err

--- a/internal/usecase/interfaces/dataset.go
+++ b/internal/usecase/interfaces/dataset.go
@@ -69,6 +69,7 @@ type Dataset interface {
 	AddDynamicDatasetSchema(context.Context, AddDynamicDatasetSchemaParam) (*dataset.Schema, error)
 	AddDynamicDataset(context.Context, AddDynamicDatasetParam) (*dataset.Schema, *dataset.Dataset, error)
 	FindBySchema(context.Context, id.DatasetSchemaID, *usecase.Pagination, *usecase.Operator) (dataset.List, *usecase.PageInfo, error)
+	CountBySchema(context.Context, id.DatasetSchemaID) (int, error)
 	FindSchemaByScene(context.Context, id.SceneID, *usecase.Pagination, *usecase.Operator) (dataset.SchemaList, *usecase.PageInfo, error)
 	FindDynamicSchemaByScene(context.Context, id.SceneID) (dataset.SchemaList, error)
 	RemoveDatasetSchema(context.Context, RemoveDatasetSchemaParam, *usecase.Operator) (id.DatasetSchemaID, error)

--- a/internal/usecase/repo/dataset.go
+++ b/internal/usecase/repo/dataset.go
@@ -13,6 +13,7 @@ type Dataset interface {
 	FindByID(context.Context, id.DatasetID) (*dataset.Dataset, error)
 	FindByIDs(context.Context, id.DatasetIDList) (dataset.List, error)
 	FindBySchema(context.Context, id.DatasetSchemaID, *usecase.Pagination) (dataset.List, *usecase.PageInfo, error)
+	CountBySchema(context.Context, id.DatasetSchemaID) (int, error)
 	FindBySchemaAll(context.Context, id.DatasetSchemaID) (dataset.List, error)
 	FindGraph(context.Context, id.DatasetID, id.DatasetFieldIDList) (dataset.List, error)
 	Save(context.Context, *dataset.Dataset) error

--- a/schema.graphql
+++ b/schema.graphql
@@ -598,6 +598,7 @@ type DatasetSchema implements Node {
   name: String!
   sceneId: ID!
   fields: [DatasetSchemaField!]!
+  totalCount: Int!
   representativeFieldId: ID
   dynamic: Boolean
   datasets(


### PR DESCRIPTION
# Overview

I fixed reearth/reearth#267.

## What I've done

- add `CountBySchema` method to count dataset by schema id.
- add totalCount resolver to DatasetSchema struct

## What I haven't done

## How I tested

1. run reearth-backend and reearth-web
2. add dataset
3. check dataset count

## Which point I want you to review particularly

## Memo
