### PR TITLE
fix: assets are not saved when files are uploaded

### DIFF
--- a/internal/infrastructure/memory/container.go
+++ b/internal/infrastructure/memory/container.go
@@ -4,10 +4,8 @@ import (
 	"github.com/reearth/reearth-backend/internal/usecase/repo"
 )
 
-func InitRepos(c *repo.Container) *repo.Container {
-	if c == nil {
-		c = &repo.Container{}
-	}
+func New() *repo.Container {
+	c := &repo.Container{}
 	c.Asset = NewAsset()
 	c.Config = NewConfig()
 	c.DatasetSchema = NewDatasetSchema()

--- a/internal/infrastructure/memory/transaction.go
+++ b/internal/infrastructure/memory/transaction.go
@@ -43,13 +43,16 @@ func (t *Transaction) Begin() (repo.Tx, error) {
 
 func (t *Tx) Commit() {
 	t.committed = true
-	if t.t != nil {
-		t.t.committed++
-	}
 }
 
 func (t *Tx) End(_ context.Context) error {
-	return t.enderror
+	if t.enderror != nil {
+		return t.enderror
+	}
+	if t.t != nil && t.committed {
+		t.t.committed++
+	}
+	return nil
 }
 
 func (t *Tx) IsCommitted() bool {

--- a/internal/infrastructure/memory/transaction_test.go
+++ b/internal/infrastructure/memory/transaction_test.go
@@ -14,9 +14,9 @@ func TestTransaction_Committed(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 0, tr.Committed())
 	tx.Commit()
-	assert.Equal(t, 1, tr.Committed())
+	assert.Equal(t, 0, tr.Committed())
 	assert.NoError(t, tx.End(context.Background()))
-	assert.NoError(t, err)
+	assert.Equal(t, 1, tr.Committed())
 }
 
 func TestTransaction_SetBeginError(t *testing.T) {

--- a/internal/usecase/interactor/asset_test.go
+++ b/internal/usecase/interactor/asset_test.go
@@ -1,0 +1,69 @@
+package interactor
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/reearth/reearth-backend/internal/infrastructure/fs"
+	"github.com/reearth/reearth-backend/internal/infrastructure/memory"
+	"github.com/reearth/reearth-backend/internal/usecase"
+	"github.com/reearth/reearth-backend/internal/usecase/gateway"
+	"github.com/reearth/reearth-backend/internal/usecase/interfaces"
+	"github.com/reearth/reearth-backend/pkg/asset"
+	"github.com/reearth/reearth-backend/pkg/file"
+	"github.com/reearth/reearth-backend/pkg/id"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAsset_Create(t *testing.T) {
+	ctx := context.Background()
+	tid := asset.NewTeamID()
+	aid := asset.NewID()
+	newID := asset.NewID
+	asset.NewID = func() asset.ID { return aid }
+	t.Cleanup(func() { asset.NewID = newID })
+
+	mfs := afero.NewMemMapFs()
+	f, _ := fs.NewFile(mfs, "")
+	repos := memory.New()
+	transaction := memory.NewTransaction()
+	repos.Transaction = transaction
+	uc := &Asset{
+		repos: repos,
+		gateways: &gateway.Container{
+			File: f,
+		},
+	}
+	buf := bytes.NewBufferString("Hello")
+	buflen := int64(buf.Len())
+	res, err := uc.Create(ctx, interfaces.CreateAssetParam{
+		TeamID: tid,
+		File: &file.File{
+			Content:     io.NopCloser(buf),
+			Path:        "hoge.txt",
+			ContentType: "",
+			Size:        buflen,
+		},
+	}, &usecase.Operator{
+		WritableTeams: id.TeamIDList{tid},
+	})
+
+	want := asset.New().
+		ID(aid).
+		Team(tid).
+		URL(res.URL()).
+		CreatedAt(aid.Timestamp()).
+		Name("hoge.txt").
+		Size(buflen).
+		ContentType("").
+		MustBuild()
+
+	assert.NoError(t, err)
+	assert.Equal(t, want, res)
+	assert.Equal(t, 1, transaction.Committed())
+	a, _ := repos.Asset.FindByID(ctx, aid)
+	assert.Equal(t, want, a)
+}

--- a/internal/usecase/interactor/layer_test.go
+++ b/internal/usecase/interactor/layer_test.go
@@ -15,7 +15,7 @@ import (
 func TestCreateInfobox(t *testing.T) {
 	ctx := context.Background()
 
-	db := memory.InitRepos(nil)
+	db := memory.New()
 	scene, _ := scene.New().NewID().Team(id.NewTeamID()).Project(id.NewProjectID()).RootLayer(id.NewLayerID()).Build()
 	_ = db.Scene.Save(ctx, scene)
 	il := NewLayer(db)

--- a/internal/usecase/interactor/plugin_upload_test.go
+++ b/internal/usecase/interactor/plugin_upload_test.go
@@ -89,7 +89,7 @@ func TestPlugin_Upload_New(t *testing.T) {
 	sid := id.NewSceneID()
 	pid := mockPluginID.WithScene(sid.Ref())
 
-	repos := memory.InitRepos(nil)
+	repos := memory.New()
 	mfs := mockFS(nil)
 	files, err := fs.NewFile(mfs, "")
 	assert.NoError(t, err)
@@ -148,7 +148,7 @@ func TestPlugin_Upload_SameVersion(t *testing.T) {
 	eid2 := id.PluginExtensionID("widget2")
 	wid1 := id.NewWidgetID()
 
-	repos := memory.InitRepos(nil)
+	repos := memory.New()
 	mfs := mockFS(map[string]string{
 		"plugins/" + pid.String() + "/hogehoge": "foobar",
 	})
@@ -263,7 +263,7 @@ func TestPlugin_Upload_DiffVersion(t *testing.T) {
 	nlpsid2 := id.NewPropertySchemaID(pid, eid2.String())
 	wid := id.NewWidgetID()
 
-	repos := memory.InitRepos(nil)
+	repos := memory.New()
 	mfs := mockFS(map[string]string{
 		"plugins/" + oldpid.String() + "/hogehoge": "foobar",
 	})

--- a/internal/usecase/interactor/property_test.go
+++ b/internal/usecase/interactor/property_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestProperty_AddItem(t *testing.T) {
 	ctx := context.Background()
-	memory := memory.InitRepos(nil)
+	memory := memory.New()
 
 	team := id.NewTeamID()
 	scene := scene.New().NewID().Team(team).RootLayer(id.NewLayerID()).MustBuild()
@@ -67,7 +67,7 @@ func TestProperty_AddItem(t *testing.T) {
 
 func TestProperty_RemoveItem(t *testing.T) {
 	ctx := context.Background()
-	memory := memory.InitRepos(nil)
+	memory := memory.New()
 
 	team := id.NewTeamID()
 	scene := scene.New().NewID().Team(team).RootLayer(id.NewLayerID()).MustBuild()
@@ -112,7 +112,7 @@ func TestProperty_RemoveItem(t *testing.T) {
 
 func TestProperty_UpdateValue_FieldOfGroupInList(t *testing.T) {
 	ctx := context.Background()
-	memory := memory.InitRepos(nil)
+	memory := memory.New()
 
 	team := id.NewTeamID()
 	scene := scene.New().NewID().Team(team).RootLayer(id.NewLayerID()).MustBuild()

--- a/internal/usecase/interactor/team_test.go
+++ b/internal/usecase/interactor/team_test.go
@@ -14,7 +14,7 @@ import (
 func TestCreateTeam(t *testing.T) {
 	ctx := context.Background()
 
-	db := memory.InitRepos(nil)
+	db := memory.New()
 
 	u := user.New().NewID().Email("aaa@bbb.com").Team(id.NewTeamID()).MustBuild()
 	teamUC := NewTeam(db)

--- a/internal/usecase/interactor/usecase_test.go
+++ b/internal/usecase/interactor/usecase_test.go
@@ -198,5 +198,5 @@ func TestRun(t *testing.T) {
 		},
 	)
 	assert.Same(t, err, goterr)
-	assert.Equal(t, 2, tr.Committed()) // committed but fails
+	assert.Equal(t, 1, tr.Committed()) // fails
 }

--- a/internal/usecase/interactor/user_signup_test.go
+++ b/internal/usecase/interactor/user_signup_test.go
@@ -263,7 +263,7 @@ func TestUser_Signup(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// t.Parallel() cannot be used
-			r := memory.InitRepos(nil)
+			r := memory.New()
 			if tt.createUserBefore != nil {
 				assert.NoError(t, r.User.Save(
 					context.Background(),
@@ -516,7 +516,7 @@ func TestUser_SignupOIDC(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// t.Parallel() cannot be used
-			r := memory.InitRepos(nil)
+			r := memory.New()
 			if tt.createUserBefore != nil {
 				assert.NoError(t, r.User.Save(
 					context.Background(),

--- a/pkg/util/now.go
+++ b/pkg/util/now.go
@@ -1,0 +1,10 @@
+package util
+
+import "time"
+
+var Now = time.Now
+
+func MockNow(t time.Time) func() {
+	Now = func() time.Time { return t }
+	return func() { Now = time.Now }
+}


### PR DESCRIPTION
# Overview

## What I've done

- Fix an issue that assets are not saved when files are uploaded
- Add a unit test for asset usecase partially
- Refactor `memory.New`
- Change `memory.Transaction.committed` behavior
