### PR TITLE
feat: change layer indicators from preset list from backend side

### DIFF
--- a/pkg/builtin/manifest.yml
+++ b/pkg/builtin/manifest.yml
@@ -178,6 +178,37 @@ extensions:
               ui: slider
               min: 0
               max: 1
+        - id: indicator
+          title: Indicator
+          description: Set the indicator in map when selecting layer.
+          fields:
+            - id: indicator_type
+              type: string
+              title: Type
+              defaultValue: default
+              description: Specify the indicator.
+              choices:
+                - key: default
+                  label: Default
+                - key: crosshair
+                  label: Crosshair
+                - key: custom
+                  label: Custom
+            - id: indicator_image
+              type: url
+              title: Image URL
+              ui: image
+              availableIf:
+                field: indicator_type
+                type: string
+                value: custom
+            - id: img_scale
+              type: number
+              title: Image scale
+              availableIf:
+                field: indicator_type
+                type: string
+                value: custom
         - id: theme
           title: Publish Theme
           description: Set your theme.
@@ -366,6 +397,10 @@ extensions:
               type: string
               title: Tracking ID
               description: Paste your Google Analytics tracking ID here. This will be embedded in your published project.
+      linkable:
+        url:
+          schemaGroupId: indicator
+          fieldId: indicator_image
   - id: infobox
     name: Infobox
     type: infobox

--- a/pkg/builtin/manifest.yml
+++ b/pkg/builtin/manifest.yml
@@ -202,7 +202,7 @@ extensions:
                 field: indicator_type
                 type: string
                 value: custom
-            - id: img_scale
+            - id: indicator_img_scale
               type: number
               title: Image scale
               availableIf:


### PR DESCRIPTION
# Overview
Layer selecting indicator: is an indicator appears when user select a layer.
We created preset list of indicators that user can choose one of them when selecting a layer.
## What I've done
I added the indicator section in manifest that will represent as right menu in the website

## What I haven't done

## How I tested

## Which point I want you to review particularly

## Memo
design link : https://www.figma.com/file/bdnfDaGXGoNfUws4y7JItl/Re%3AEarth-UI-Gamma?node-id=10319%3A174052
frontend PR: https://github.com/reearth/reearth-web/pull/245